### PR TITLE
feat: make moveDialog look beautiful,add tip to show long description.

### DIFF
--- a/src/Ankimon/classes/choose_move_dialog.py
+++ b/src/Ankimon/classes/choose_move_dialog.py
@@ -29,7 +29,8 @@ class MoveSelectionDialog(QDialog):
         self.move_labels = []
         for index, move in enumerate(mainpokemon_attacks):
             move_detail = find_details_move(move)
-            move_label = QLabel(f"{index + 1}. {move}({move_detail['basePower']}): {move_detail['desc']}")
+            move_label = QLabel(f"{index + 1}. {move}({move_detail['basePower']}): {move_detail['shortDesc']}")
+            move_label.setToolTip(f"{move_detail['desc']}")
             move_label.setFont(QFont("Arial", 12))
             move_label.setAlignment(Qt.AlignmentFlag.AlignLeft | Qt.AlignmentFlag.AlignVCenter)
             move_label.setStyleSheet("border: 1px solid #ccc; border-radius: 0px;")  # Removed padding, reduced border-radius


### PR DESCRIPTION
Some pokemon's skill descriptions are too long, I use tip to display, and the skill box shows a short description.

See pictures for more details

![bb2ac2da446bfcbabd36f8ab41dc6a20](https://github.com/user-attachments/assets/68f87e11-5f5a-4986-a998-8ffa7b12e73a)
