### PR TITLE
Indentation fix in translator.py

### DIFF
--- a/src/Ankimon/pyobj/translator.py
+++ b/src/Ankimon/pyobj/translator.py
@@ -43,29 +43,29 @@ class Translator:
             raise Exception(f"Invalid JSON format in translation file: {self.filepath}")
 
     def translate(self, key, **kwargs):
-    # Track which translation file is being used
-    source_file = self.filepath
-    template = self.translations.get(key, None)
-    
-    # Fallback to English if key not found
-    if template is None:
-        try:
-            with open(lang_path_en, 'r', encoding='utf-8') as f:
-                fallback_translations = json.load(f)
-            template = fallback_translations.get(key, key)
-            source_file = lang_path_en  # Now using fallback file
-        except Exception as e:
-            raise Exception(f"Fallback translation failed: {str(e)}")
+        # Track which translation file is being used
+        source_file = self.filepath
+        template = self.translations.get(key, None)
+        
+        # Fallback to English if key not found
+        if template is None:
+            try:
+                with open(lang_path_en, 'r', encoding='utf-8') as f:
+                    fallback_translations = json.load(f)
+                template = fallback_translations.get(key, key)
+                source_file = lang_path_en  # Now using fallback file
+            except Exception as e:
+                raise Exception(f"Fallback translation failed: {str(e)}")
 
-    try:
-        return template.format(**kwargs)
-    except KeyError as e:
-        missing_key = str(e).strip("'")
-        available = list(kwargs.keys())
-        raise Exception(
-            f"Translation error in key '{key}'\n"
-            f"• Missing placeholder: {missing_key}\n"
-            f"• Translation file: {source_file}\n"
-            f"• Available arguments: {available}"
-        )
+        try:
+            return template.format(**kwargs)
+        except KeyError as e:
+            missing_key = str(e).strip("'")
+            available = list(kwargs.keys())
+            raise Exception(
+                f"Translation error in key '{key}'\n"
+                f"• Missing placeholder: {missing_key}\n"
+                f"• Translation file: {source_file}\n"
+                f"• Available arguments: {available}"
+            )
 


### PR DESCRIPTION
Sorry I'm dumb, I put a proper function without aligning it correctly
translator.py has more info now when error is caught, and the function is aligned properly now
```
if template is None:
            try:
                with open(lang_path_en, 'r', encoding='utf-8') as f:
                    fallback_translations = json.load(f)
                template = fallback_translations.get(key, key)
                source_file = lang_path_en  # Now using fallback file
            except Exception as e:
                raise Exception(f"Fallback translation failed: {str(e)}")

        try:
            return template.format(**kwargs)
        except KeyError as e:
            missing_key = str(e).strip("'")
            available = list(kwargs.keys())
            raise Exception(
                f"Translation error in key '{key}'\n"
                f"• Missing placeholder: {missing_key}\n"
                f"• Translation file: {source_file}\n"
                f"• Available arguments: {available}"
            )

```