### PR TITLE
Shiny Pokemon blank nickname fix

### DIFF
--- a/src/Ankimon/__init__.py
+++ b/src/Ankimon/__init__.py
@@ -1105,7 +1105,7 @@ def save_main_pokemon_progress(mainpokemon_path, mainpokemon_level, mainpokemon_
             pass
         if settings_obj.get('gui.pop_up_dialog_message_on_defeat', True) is True:
             logger.log_and_showinfo("info",f"{msg}")
-        main_pokemon.xp = int(max(0, int(main_pokemon.x) - int(experience)))
+        main_pokemon.xp = int(max(0, int(main_pokemon.xp) - int(experience)))
         evo_id = check_evolution_for_pokemon(main_pokemon.individual_id, main_pokemon.id, main_pokemon.level, evo_window, main_pokemon.everstone)
         if evo_id is not None:
             msg += translator.translate("pokemon_about_to_evolve", main_pokemon_name=main_pokemon.name, evo_pokemon_name=return_name_for_id(evo_id).capitalize(), main_pokemon_level=main_pokemon.level)

--- a/src/Ankimon/lang/en_text.json
+++ b/src/Ankimon/lang/en_text.json
@@ -9,7 +9,7 @@
     "level": "Level",
     "error_occured": "An error occured with {function} Please post this error message over the Report Bug Issue",
     "missing_mainpokemon_data": "Missing pokemon data",
-    "pokemon_about_to_evolve": "{main_pokemon_name} is about to evolve to {evo_pokemon_name)} at level {main_pokemon_level}",
+    "pokemon_about_to_evolve": "{main_pokemon_name} is about to evolve to {evo_pokemon_name} at level {main_pokemon_level}",
     "mainpokemon_can_learn_new_attack": "Your {main_pokemon_name} can learn a new attack !",
     "mainpokemon_learned_new_attack": "Your {main_pokemon_name} learned {new_attack_name} !",
     "mainpokemon_gained_xp": "Your {main_pokemon_name} has gained {exp} XP.\n {experience_till_next_level} exp is needed for next level \n Your pokemon currently has {main_pokemon_xp}",

--- a/src/Ankimon/pyobj/collection_dialog.py
+++ b/src/Ankimon/pyobj/collection_dialog.py
@@ -161,10 +161,11 @@ class PokemonCollectionDialog(QDialog):
                 pokemon_id = pokemon['id']
                 pokemon_name = pokemon['name']
                 pokemon_shiny = pokemon.get("shiny", False)
-                pokemon_nickname = pokemon.get('nickname', '')
+                # Ensure nickname is always a string, even if None
+                pokemon_nickname = pokemon.get('nickname') or ''
                 if pokemon_shiny:
                     pokemon_nickname += " ⭐ "
-                pokemon_gender = pokemon['gender']
+                pokemon_gender = pokemon.get("gender", "M")
                 pokemon_level = pokemon['level']
                 pokemon_ability = pokemon['ability']
                 pokemon_type = pokemon['type']
@@ -172,8 +173,13 @@ class PokemonCollectionDialog(QDialog):
                 pokemon_hp = pokemon_stats["hp"]
                 if pokemon_shiny:
                     pokemon_name += " ⭐ "
-                pokemon_gender = pokemon.get("gender", "M")
-                pkmn_image_path = get_sprite_path("front", "gif" if self.gif_in_collection else "png", pokemon_id, pokemon_shiny, pokemon_gender)
+                pkmn_image_path = get_sprite_path(
+                    "front",
+                    "gif" if self.gif_in_collection else "png",
+                    pokemon_id,
+                    pokemon_shiny,
+                    pokemon_gender
+                )
 
                 if self.gif_in_collection:
                     splash_label = MovieSplashLabel(pkmn_image_path)
@@ -181,7 +187,9 @@ class PokemonCollectionDialog(QDialog):
                 pixmap = QPixmap(pkmn_image_path)
                 pixmap = self.adjust_pixmap_size(pixmap, max_width=300, max_height=230)
 
-                name_label = self.create_label(pokemon_nickname or f"{pokemon_name.capitalize()} {self.get_gender_symbol(pokemon_gender)}", 12)
+                name_label = self.create_label(
+                    pokemon_nickname or f"{pokemon_name.capitalize()} {self.get_gender_symbol(pokemon_gender)}", 12
+                )
                 level_label = self.create_label(f"Level: {pokemon_level}", 8)
                 type_label = self.create_label("Type: " + " ".join([t.capitalize() for t in pokemon_type]), 8)
                 ability_label = self.create_label(f"Ability: {pokemon_ability.capitalize()}", 8)

--- a/src/Ankimon/pyobj/collection_dialog.py
+++ b/src/Ankimon/pyobj/collection_dialog.py
@@ -329,7 +329,7 @@ class PokemonCollectionDialog(QDialog):
                         pokemon_name = pokemon['name'].lower()
                         if pokemon.get("shiny", False):
                             pokemon_name += " (shiny) "
-                        pokemon_nickname = pokemon.get("nickname", None)
+                        pokemon_nickname = pokemon.get('nickname') or ''
                         if pokemon.get("shiny", False):
                             pokemon_nickname += " (shiny) "
                         pokemon_type = pokemon.get("type", " ")
@@ -383,7 +383,7 @@ class PokemonCollectionDialog(QDialog):
                     pokemon_name = pokemon['name'].lower()
                     if pokemon.get("shiny", False):
                         pokemon_name += " (shiny) "
-                    pokemon_nickname = pokemon.get("nickname", None)
+                    pokemon_nickname = pokemon.get('nickname') or ''
                     if pokemon.get("shiny", False):
                         pokemon_nickname += " (shiny) "
                     pokemon_type = pokemon.get("type", " ")


### PR DESCRIPTION
If there is blank nickname for shiny pokemon, text concatenation does not return error