### PR TITLE
Allow metronome to choose a random attack

### DIFF
--- a/src/Ankimon/__init__.py
+++ b/src/Ankimon/__init__.py
@@ -1707,7 +1707,7 @@ def on_review_card(*args):
                         reviewer_obj.myseconds = 0
                         msg += translator.translate("dmg_dealt", dmg=enemy_dmg, pokemon_name=main_pokemon.name.capitalize())
     
-            # if enemy pokemon hp < 0 - attack enemy pokemon
+            # if enemy pokemon hp > 0 - attack enemy pokemon
             if ankimon_tracker_obj.pokemon_encouter > 0 and main_pokemon.hp > 0 and enemy_pokemon.hp > 0:
                 dmg = 0
                 random_attack = random.choice(main_pokemon.attacks)
@@ -1718,7 +1718,7 @@ def on_review_card(*args):
                             random_attack = dialog.selected_move
                 msg += "\n"
                 msg += translator.translate("pokemon_chose_attack", pokemon_name=main_pokemon.name.capitalize(), pokemon_attack=random_attack.capitalize())
-                move = find_details_move(random_attack)
+                move = find_details_move(random_attack, True)
                 category = move.get("category")
                 acc = move.get("accuracy")
                 if battle_status != "fighting":

--- a/src/Ankimon/functions/pokedex_functions.py
+++ b/src/Ankimon/functions/pokedex_functions.py
@@ -219,13 +219,29 @@ def get_all_pokemon_moves(pk_name, level):
 
         return attacks
 
-def find_details_move(move_name):
+def find_details_move(move_name, allow_metronome_random=False):
+    """
+    Find the details of a move by its name.
+
+    Args:
+        move_name (str): The name of the move to search for.
+        allow_metronome_random (bool): If True, allows "metronome" to return a random move's details. Defaults to True.
+
+    Returns:
+        dict or None: The details of the move if found, or None if not found.
+    """
     try:
         with open(moves_file_path, "r", encoding="utf-8") as json_file:
             moves_data = json.load(json_file)
+
+            if allow_metronome_random and move_name.lower() == "metronome":
+                random_move = random.choice(list(moves_data.keys()))
+                return moves_data.get(random_move)
+
             move = moves_data.get(move_name.lower())  # Use get() to access the move by name
             if move:
                 return move
+
             move_name = move_name.replace(" ", "")
             try:
                 move = moves_data.get(move_name.lower())
@@ -241,7 +257,8 @@ def find_details_move(move_name):
         #logger.log_and_showinfo("info",f"Error decoding JSON: {e}")
         return None
     except Exception as e:
-        showWarning(f"There is an issue in find_details_move{e}")
+        showWarning(f"There is an issue in find_details_move: {e}")
+        return None
 
 def get_pokemon_evolution_data_all(pokemon_id, file_path=poke_evo_path):
     # Open the CSV file

--- a/src/Ankimon/functions/pokedex_functions.py
+++ b/src/Ankimon/functions/pokedex_functions.py
@@ -225,7 +225,7 @@ def find_details_move(move_name, allow_metronome_random=False):
 
     Args:
         move_name (str): The name of the move to search for.
-        allow_metronome_random (bool): If True, allows "metronome" to return a random move's details. Defaults to True.
+        allow_metronome_random (bool): If True, allows "metronome" to return a random move's details.
 
     Returns:
         dict or None: The details of the move if found, or None if not found.


### PR DESCRIPTION
Allow metronome to choose a random attack if the user is the player's pokémon. Note that this does not apply to the enemy's Pokémon.
I can't see any unit tests or similar to ensure that this does not break anything so let me know if there are any steps I should take to ensure this doesn't cause issues. I have tested this locally and haven't seen any problems, but due to the nature of metronome if there is a move that is broken then there is a small chance it is executed.