### PR TITLE
fix bug with search_pokedex_by_id

### DIFF
--- a/src/Ankimon/functions/pokedex_functions.py
+++ b/src/Ankimon/functions/pokedex_functions.py
@@ -83,6 +83,8 @@ def search_pokedex_by_id(pokemon_id):
     with open(str(pokedex_path), "r", encoding="utf-8") as json_file:
             pokedex_data = json.load(json_file) 
             for entry_name, attributes in pokedex_data.items():
+                if "num" not in attributes:
+                    continue   #skip entries without num attribute in pokedex (most pokemon variants for new gens)
                 if attributes['num'] == pokemon_id:
                     return entry_name
     return 'Pokémon not found'


### PR DESCRIPTION
After doing some debugging, it appeared that "search_pokedex_by_id" function was breaking due to newer generation pokemon not having a num attribute in the pokedex json file. Whenever it would run the for loop to get num id's for the pokemon, it got to a variant pokemon and would break due to this. 

I did a closer inspection and saw that only the 0th index and nth index for a pokemon with variants had a num and skills, every variant in between  didn't have any of the other required information such as moves, abilities, etc. 

I just added some slight code to the search_pokedex_by_id() function that will skip any pokemon that don't have a num attribute that way it will continue to work. If you wish to fix the pokedex with abilities and num attributes that will solve the root cause of the problem. 