### PR TITLE
Battle hardening + multiplayer raid feature

### DIFF
--- a/.github/workflows/raid-server.yml
+++ b/.github/workflows/raid-server.yml
@@ -1,0 +1,36 @@
+name: Raid Server
+
+on:
+  push:
+    paths:
+      - "raid-server/**"
+      - ".github/workflows/raid-server.yml"
+  pull_request:
+    paths:
+      - "raid-server/**"
+      - ".github/workflows/raid-server.yml"
+
+jobs:
+  test:
+    name: go build & test
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: raid-server
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Build
+        run: go build ./...
+
+      - name: Test
+        run: go test ./... -race -v

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,24 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  pytest:
+    name: pytest (battle logic)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Install test dependencies
+        run: python -m pip install pytest requests
+
+      - name: Run tests
+        run: python -m pytest tests/ -v

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 __pycache__/
 *.pyc
 .pytest_cache/
+raid-server/*.exe
+raid-server/ankimon-raid-server

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 
 /src/Ankimon/classes/__pycache__
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/raid-server/README.md
+++ b/raid-server/README.md
@@ -28,14 +28,19 @@ There's no real account system yet (v1 matches the addon's leaderboard
 feature, which is also "well-formed credentials", not verified identity) -
 this exists to keep anonymous/accidental traffic out, not to authenticate.
 
+The participant identity for `/join` and `/attack` always comes from the
+`X-Ankimon-Username` header, never from a body field - a request body has no
+way to act as, join as, or attack as a different trainer than whoever
+authenticated the request.
+
 | Method | Path                  | Body                                                                 | Notes |
 |--------|-----------------------|-----------------------------------------------------------------------|-------|
 | GET    | `/healthz`            | -                                                                     | no auth required |
 | POST   | `/raids`               | `{"boss_name","boss_level","max_hp"}`                                 | creates a raid, returns it with a short `id` |
 | GET    | `/raids`               | -                                                                     | lists raids whose boss hasn't been defeated yet |
 | GET    | `/raids/{id}`          | -                                                                     | full raid state, including participants |
-| POST   | `/raids/{id}/join`     | `{"username"}`                                                        | idempotent - joining twice is a no-op |
-| POST   | `/raids/{id}/attack`   | `{"username","damage","level","base_power","atk_stat","def_stat"}`    | see below |
+| POST   | `/raids/{id}/join`     | `{}`                                                                   | idempotent - joining twice is a no-op |
+| POST   | `/raids/{id}/attack`   | `{"damage","level","base_power","atk_stat","def_stat"}`               | see below |
 
 ### Anti-cheat on `/attack`
 
@@ -50,7 +55,10 @@ compare it to what you sent if you need to detect clamping.
 This is an approximation (no access to the addon's type effectiveness chart
 server-side), tuned to always let legitimate hits through and only reject
 physically-impossible claims - not a byte-for-byte reimplementation of the
-Python damage formula.
+Python damage formula. `level`/`base_power`/`atk_stat`/`def_stat` are
+themselves clamped to real-game-plausible ranges before the ceiling is
+computed, so a client can't inflate its own ceiling by claiming an absurd
+level or stat.
 
 ## Manual smoke test
 
@@ -65,10 +73,10 @@ echo "$RAID"
 # grab "id" from the response, then:
 curl -s -X POST http://localhost:8080/raids/<id>/join \
   -H "X-Ankimon-Username: leon" -H "X-Ankimon-Api-Key: k" \
-  -d '{"username":"leon"}'
+  -d '{}'
 curl -s -X POST http://localhost:8080/raids/<id>/attack \
   -H "X-Ankimon-Username: leon" -H "X-Ankimon-Api-Key: k" \
-  -d '{"username":"leon","damage":25,"level":20,"base_power":40,"atk_stat":50,"def_stat":50}'
+  -d '{"damage":25,"level":20,"base_power":40,"atk_stat":50,"def_stat":50}'
 ```
 
 ## Not implemented yet (v1 scope)

--- a/raid-server/README.md
+++ b/raid-server/README.md
@@ -1,0 +1,80 @@
+# ankimon raid server
+
+A small self-hostable relay server for Ankimon's raid feature: multiple
+trainers fight a shared boss Pokemon together, dealing damage as they review
+Anki cards. In-memory only (no database) - state resets on restart.
+
+## Running it
+
+```sh
+go run .
+# or
+go build -o ankimon-raid-server .
+./ankimon-raid-server
+```
+
+Listens on `:8080` by default; override with the `PORT` env var.
+
+## API
+
+Every request except `GET /healthz` requires two headers:
+
+```
+X-Ankimon-Username: <trainer name>
+X-Ankimon-Api-Key: <any non-empty value>
+```
+
+There's no real account system yet (v1 matches the addon's leaderboard
+feature, which is also "well-formed credentials", not verified identity) -
+this exists to keep anonymous/accidental traffic out, not to authenticate.
+
+| Method | Path                  | Body                                                                 | Notes |
+|--------|-----------------------|-----------------------------------------------------------------------|-------|
+| GET    | `/healthz`            | -                                                                     | no auth required |
+| POST   | `/raids`               | `{"boss_name","boss_level","max_hp"}`                                 | creates a raid, returns it with a short `id` |
+| GET    | `/raids`               | -                                                                     | lists raids whose boss hasn't been defeated yet |
+| GET    | `/raids/{id}`          | -                                                                     | full raid state, including participants |
+| POST   | `/raids/{id}/join`     | `{"username"}`                                                        | idempotent - joining twice is a no-op |
+| POST   | `/raids/{id}/attack`   | `{"username","damage","level","base_power","atk_stat","def_stat"}`    | see below |
+
+### Anti-cheat on `/attack`
+
+The client computes its own damage locally (same formula the addon already
+uses for solo battles) and submits it, along with the inputs that produced
+it. The server independently computes a generous theoretical ceiling for
+that same formula (`damage.go: maxPossibleDamage`) and clamps the claim to
+it - so a modified client can't report arbitrary damage against the shared
+boss. The response's `damage_accepted` field is the number actually applied;
+compare it to what you sent if you need to detect clamping.
+
+This is an approximation (no access to the addon's type effectiveness chart
+server-side), tuned to always let legitimate hits through and only reject
+physically-impossible claims - not a byte-for-byte reimplementation of the
+Python damage formula.
+
+## Manual smoke test
+
+```sh
+go run . &
+curl -s http://localhost:8080/healthz
+
+RAID=$(curl -s -X POST http://localhost:8080/raids \
+  -H "X-Ankimon-Username: leon" -H "X-Ankimon-Api-Key: k" \
+  -d '{"boss_name":"Rayquaza","boss_level":70,"max_hp":500}')
+echo "$RAID"
+# grab "id" from the response, then:
+curl -s -X POST http://localhost:8080/raids/<id>/join \
+  -H "X-Ankimon-Username: leon" -H "X-Ankimon-Api-Key: k" \
+  -d '{"username":"leon"}'
+curl -s -X POST http://localhost:8080/raids/<id>/attack \
+  -H "X-Ankimon-Username: leon" -H "X-Ankimon-Api-Key: k" \
+  -d '{"username":"leon","damage":25,"level":20,"base_power":40,"atk_stat":50,"def_stat":50}'
+```
+
+## Not implemented yet (v1 scope)
+
+- Real-time push - clients poll `GET /raids/{id}`. A websocket upgrade is a
+  natural v2 addition on top of the same `Store`.
+- Persistence - an in-process restart drops all raid state.
+- Deployment/hosting - this is just the server; where it runs is up to you
+  (a `Dockerfile`/Fly.io/Render config can be added when you pick one).

--- a/raid-server/damage.go
+++ b/raid-server/damage.go
@@ -1,6 +1,33 @@
 package main
 
-// clampDamage bounds a client-submitted damage number to a theoretical
+import "math"
+
+// Sane bounds for the inputs used to compute a damage ceiling. Pokemon stats
+// and levels are bounded in the real game; a client claiming, say, level
+// 999999999 to blow the ceiling wide open (or overflow the float64->int
+// conversion below) gets clamped to these before anything is computed.
+const (
+	minLevel = 1
+	maxLevel = 100
+
+	minStat = 1
+	maxStat = 999 // generous ceiling above any real in-game stat (even fully IV/EV maxed + boosted)
+
+	minBasePower = 1
+	maxBasePower = 250 // highest base power moves in the addon's data top out well under this
+)
+
+func clampInt(v, lo, hi int) int {
+	if v < lo {
+		return lo
+	}
+	if v > hi {
+		return hi
+	}
+	return v
+}
+
+// maxPossibleDamage bounds a client-submitted damage number to a theoretical
 // ceiling derived from the same formula the addon uses client-side
 // (functions/battle_functions.py: calc_atk_dmg), so one participant can't
 // claim arbitrary damage against the shared boss.
@@ -11,10 +38,16 @@ package main
 // variable that isn't sent by the client (max crit, max STAB, max dual-type
 // effectiveness, max random-luck roll). That means a legitimate hit is
 // always allowed through; only physically-impossible claims get clamped.
+//
+// All inputs are clamped to real-game-plausible ranges first - both to stop
+// someone gaming the ceiling upward by claiming an absurd level/stat, and to
+// keep the float64 math (and the final conversion back to int) well inside
+// safe range.
 func maxPossibleDamage(level, basePower, atkStat, defStat int) int {
-	if level <= 0 || basePower <= 0 || atkStat <= 0 || defStat <= 0 {
-		return 0
-	}
+	level = clampInt(level, minLevel, maxLevel)
+	basePower = clampInt(basePower, minBasePower, maxBasePower)
+	atkStat = clampInt(atkStat, minStat, maxStat)
+	defStat = clampInt(defStat, minStat, maxStat)
 
 	const (
 		maxCriticalMultiplier = 4.0 // observed ceiling of the addon's "critical" (round-performance x crit) term
@@ -29,8 +62,17 @@ func maxPossibleDamage(level, basePower, atkStat, defStat int) int {
 	def := float64(defStat)
 
 	dmg := ((((2*l*maxCriticalMultiplier)+2)/5)*p*atk/def + 2) / 50 * maxStab * maxEffectiveness * maxRandomFactor
-	if dmg < 0 {
+
+	// With the clamps above this can no longer realistically approach
+	// MaxInt, but guard the float->int conversion anyway: converting a
+	// float64 that's NaN, +/-Inf, or out of the int range is undefined
+	// behaviour in Go, not a clean saturation.
+	if math.IsNaN(dmg) || dmg < 0 {
 		return 0
+	}
+	const hardCeiling = 1_000_000
+	if dmg > hardCeiling {
+		return hardCeiling
 	}
 	return int(dmg)
 }

--- a/raid-server/damage.go
+++ b/raid-server/damage.go
@@ -1,0 +1,48 @@
+package main
+
+// clampDamage bounds a client-submitted damage number to a theoretical
+// ceiling derived from the same formula the addon uses client-side
+// (functions/battle_functions.py: calc_atk_dmg), so one participant can't
+// claim arbitrary damage against the shared boss.
+//
+// This is deliberately an approximation, not a byte-for-byte reimplementation
+// of the Python formula: it doesn't have access to the addon's type
+// effectiveness chart, so it assumes the most generous case for every
+// variable that isn't sent by the client (max crit, max STAB, max dual-type
+// effectiveness, max random-luck roll). That means a legitimate hit is
+// always allowed through; only physically-impossible claims get clamped.
+func maxPossibleDamage(level, basePower, atkStat, defStat int) int {
+	if level <= 0 || basePower <= 0 || atkStat <= 0 || defStat <= 0 {
+		return 0
+	}
+
+	const (
+		maxCriticalMultiplier = 4.0 // observed ceiling of the addon's "critical" (round-performance x crit) term
+		maxStab               = 1.5
+		maxEffectiveness      = 4.0 // double-super-effective across a dual type
+		maxRandomFactor       = 1.0 // random.randint(217,255)/255 tops out at 1.0
+	)
+
+	l := float64(level)
+	p := float64(basePower)
+	atk := float64(atkStat)
+	def := float64(defStat)
+
+	dmg := ((((2*l*maxCriticalMultiplier)+2)/5)*p*atk/def + 2) / 50 * maxStab * maxEffectiveness * maxRandomFactor
+	if dmg < 0 {
+		return 0
+	}
+	return int(dmg)
+}
+
+// clampDamage returns claimedDamage clamped to [0, maxPossibleDamage(...)].
+func clampDamage(claimedDamage, level, basePower, atkStat, defStat int) int {
+	if claimedDamage < 0 {
+		return 0
+	}
+	ceiling := maxPossibleDamage(level, basePower, atkStat, defStat)
+	if claimedDamage > ceiling {
+		return ceiling
+	}
+	return claimedDamage
+}

--- a/raid-server/damage_test.go
+++ b/raid-server/damage_test.go
@@ -2,7 +2,11 @@ package main
 
 import "testing"
 
-func TestMaxPossibleDamageZeroOnInvalidInput(t *testing.T) {
+func TestMaxPossibleDamageClampsInvalidInputsInsteadOfZero(t *testing.T) {
+	// Non-positive/out-of-range inputs get clamped to sane bounds (not
+	// treated as "zero damage") - a client can't zero out or invert the
+	// ceiling by sending garbage.
+	baseline := maxPossibleDamage(10, 40, 50, 50)
 	cases := [][4]int{
 		{0, 40, 50, 50},
 		{10, 0, 50, 50},
@@ -10,9 +14,21 @@ func TestMaxPossibleDamageZeroOnInvalidInput(t *testing.T) {
 		{10, 40, 50, 0},
 	}
 	for _, c := range cases {
-		if got := maxPossibleDamage(c[0], c[1], c[2], c[3]); got != 0 {
-			t.Errorf("maxPossibleDamage(%v) = %d, want 0", c, got)
+		got := maxPossibleDamage(c[0], c[1], c[2], c[3])
+		if got <= 0 {
+			t.Errorf("maxPossibleDamage(%v) = %d, want a clamped positive ceiling", c, got)
 		}
+		_ = baseline
+	}
+}
+
+func TestMaxPossibleDamageClampsAbsurdInputsUpward(t *testing.T) {
+	// A client claiming an absurd level/stat to inflate its own damage
+	// ceiling must not get a bigger ceiling than the in-game max would give.
+	realistic := maxPossibleDamage(100, 250, 999, 1)
+	gamed := maxPossibleDamage(999999999, 999999999, 999999999, 1)
+	if gamed != realistic {
+		t.Fatalf("expected absurd inputs to clamp to the same ceiling as max realistic inputs (%d), got %d", realistic, gamed)
 	}
 }
 
@@ -21,6 +37,13 @@ func TestMaxPossibleDamageIncreasesWithLevel(t *testing.T) {
 	high := maxPossibleDamage(50, 40, 50, 50)
 	if high <= low {
 		t.Fatalf("expected higher level to raise the damage ceiling: low=%d high=%d", low, high)
+	}
+}
+
+func TestMaxPossibleDamageNeverExceedsHardCeiling(t *testing.T) {
+	got := maxPossibleDamage(100, 250, 999, 1)
+	if got > 1_000_000 {
+		t.Fatalf("expected the hard ceiling to cap even the most extreme legal inputs, got %d", got)
 	}
 }
 

--- a/raid-server/damage_test.go
+++ b/raid-server/damage_test.go
@@ -1,0 +1,46 @@
+package main
+
+import "testing"
+
+func TestMaxPossibleDamageZeroOnInvalidInput(t *testing.T) {
+	cases := [][4]int{
+		{0, 40, 50, 50},
+		{10, 0, 50, 50},
+		{10, 40, 0, 50},
+		{10, 40, 50, 0},
+	}
+	for _, c := range cases {
+		if got := maxPossibleDamage(c[0], c[1], c[2], c[3]); got != 0 {
+			t.Errorf("maxPossibleDamage(%v) = %d, want 0", c, got)
+		}
+	}
+}
+
+func TestMaxPossibleDamageIncreasesWithLevel(t *testing.T) {
+	low := maxPossibleDamage(5, 40, 50, 50)
+	high := maxPossibleDamage(50, 40, 50, 50)
+	if high <= low {
+		t.Fatalf("expected higher level to raise the damage ceiling: low=%d high=%d", low, high)
+	}
+}
+
+func TestClampDamagePassesThroughReasonableClaims(t *testing.T) {
+	ceiling := maxPossibleDamage(20, 40, 50, 50)
+	reasonable := ceiling / 2
+	if got := clampDamage(reasonable, 20, 40, 50, 50); got != reasonable {
+		t.Fatalf("expected reasonable damage to pass through unclamped, got %d want %d", got, reasonable)
+	}
+}
+
+func TestClampDamageCapsAtCeiling(t *testing.T) {
+	ceiling := maxPossibleDamage(20, 40, 50, 50)
+	if got := clampDamage(ceiling*100, 20, 40, 50, 50); got != ceiling {
+		t.Fatalf("expected damage to be clamped to the ceiling (%d), got %d", ceiling, got)
+	}
+}
+
+func TestClampDamageRejectsNegative(t *testing.T) {
+	if got := clampDamage(-50, 20, 40, 50, 50); got != 0 {
+		t.Fatalf("expected negative damage to clamp to 0, got %d", got)
+	}
+}

--- a/raid-server/go.mod
+++ b/raid-server/go.mod
@@ -1,0 +1,3 @@
+module github.com/Unlucky-Life/ankimon/raid-server
+
+go 1.22

--- a/raid-server/handlers.go
+++ b/raid-server/handlers.go
@@ -56,18 +56,16 @@ func getRaidHandler(store *Store) http.HandlerFunc {
 	}
 }
 
-type joinRaidRequest struct {
-	Username string `json:"username"`
-}
+// joinRaidHandler and attackRaidHandler intentionally do NOT accept a
+// "username" field in the request body - the participant identity always
+// comes from the authenticated X-Ankimon-Username header (see
+// authenticatedUsername/requireCredentials in main.go). Trusting a
+// body-supplied username would let any authenticated caller act, join, or
+// deal damage as anyone else.
 
 func joinRaidHandler(store *Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		var req joinRaidRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON body"})
-			return
-		}
-		raid, err := store.Join(r.PathValue("id"), req.Username)
+		raid, err := store.Join(r.PathValue("id"), authenticatedUsername(r))
 		if err != nil {
 			writeJSON(w, statusForError(err), map[string]string{"error": err.Error()})
 			return
@@ -77,12 +75,11 @@ func joinRaidHandler(store *Store) http.HandlerFunc {
 }
 
 type attackRaidRequest struct {
-	Username  string `json:"username"`
-	Damage    int    `json:"damage"`     // damage the client computed locally
-	Level     int    `json:"level"`      // attacker's Pokemon level
-	BasePower int    `json:"base_power"` // move base power
-	AtkStat   int    `json:"atk_stat"`
-	DefStat   int    `json:"def_stat"`
+	Damage    int `json:"damage"`     // damage the client computed locally
+	Level     int `json:"level"`      // attacker's Pokemon level
+	BasePower int `json:"base_power"` // move base power
+	AtkStat   int `json:"atk_stat"`
+	DefStat   int `json:"def_stat"`
 }
 
 type attackRaidResponse struct {
@@ -97,7 +94,7 @@ func attackRaidHandler(store *Store) http.HandlerFunc {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON body"})
 			return
 		}
-		raid, accepted, err := store.Attack(r.PathValue("id"), req.Username, req.Damage, req.Level, req.BasePower, req.AtkStat, req.DefStat)
+		raid, accepted, err := store.Attack(r.PathValue("id"), authenticatedUsername(r), req.Damage, req.Level, req.BasePower, req.AtkStat, req.DefStat)
 		if err != nil {
 			writeJSON(w, statusForError(err), map[string]string{"error": err.Error()})
 			return

--- a/raid-server/handlers.go
+++ b/raid-server/handlers.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+func registerRoutes(mux *http.ServeMux, store *Store) {
+	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+	})
+
+	mux.HandleFunc("POST /raids", createRaidHandler(store))
+	mux.HandleFunc("GET /raids", listRaidsHandler(store))
+	mux.HandleFunc("GET /raids/{id}", getRaidHandler(store))
+	mux.HandleFunc("POST /raids/{id}/join", joinRaidHandler(store))
+	mux.HandleFunc("POST /raids/{id}/attack", attackRaidHandler(store))
+}
+
+type createRaidRequest struct {
+	BossName  string `json:"boss_name"`
+	BossLevel int    `json:"boss_level"`
+	MaxHP     int    `json:"max_hp"`
+}
+
+func createRaidHandler(store *Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req createRaidRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON body"})
+			return
+		}
+		if req.BossName == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "boss_name is required"})
+			return
+		}
+		raid := store.CreateRaid(req.BossName, req.BossLevel, req.MaxHP)
+		writeJSON(w, http.StatusCreated, raid)
+	}
+}
+
+func listRaidsHandler(store *Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, http.StatusOK, store.ListActive())
+	}
+}
+
+func getRaidHandler(store *Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		raid, err := store.Get(r.PathValue("id"))
+		if err != nil {
+			writeJSON(w, http.StatusNotFound, map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, raid)
+	}
+}
+
+type joinRaidRequest struct {
+	Username string `json:"username"`
+}
+
+func joinRaidHandler(store *Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req joinRaidRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON body"})
+			return
+		}
+		raid, err := store.Join(r.PathValue("id"), req.Username)
+		if err != nil {
+			writeJSON(w, statusForError(err), map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, raid)
+	}
+}
+
+type attackRaidRequest struct {
+	Username  string `json:"username"`
+	Damage    int    `json:"damage"`     // damage the client computed locally
+	Level     int    `json:"level"`      // attacker's Pokemon level
+	BasePower int    `json:"base_power"` // move base power
+	AtkStat   int    `json:"atk_stat"`
+	DefStat   int    `json:"def_stat"`
+}
+
+type attackRaidResponse struct {
+	Raid           *Raid `json:"raid"`
+	DamageAccepted int   `json:"damage_accepted"`
+}
+
+func attackRaidHandler(store *Store) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		var req attackRaidRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON body"})
+			return
+		}
+		raid, accepted, err := store.Attack(r.PathValue("id"), req.Username, req.Damage, req.Level, req.BasePower, req.AtkStat, req.DefStat)
+		if err != nil {
+			writeJSON(w, statusForError(err), map[string]string{"error": err.Error()})
+			return
+		}
+		writeJSON(w, http.StatusOK, attackRaidResponse{Raid: raid, DamageAccepted: accepted})
+	}
+}
+
+func statusForError(err error) int {
+	switch err {
+	case ErrRaidNotFound:
+		return http.StatusNotFound
+	case ErrRaidAlreadyOver:
+		return http.StatusConflict
+	case ErrParticipantEmpty:
+		return http.StatusBadRequest
+	default:
+		return http.StatusInternalServerError
+	}
+}

--- a/raid-server/main.go
+++ b/raid-server/main.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+)
+
+func main() {
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	store := NewStore()
+	mux := http.NewServeMux()
+	registerRoutes(mux, store)
+
+	log.Printf("ankimon raid server listening on :%s", port)
+	if err := http.ListenAndServe(":"+port, requireCredentials(mux)); err != nil {
+		log.Fatal(err)
+	}
+}
+
+// requireCredentials enforces that every request carries non-empty
+// X-Ankimon-Username / X-Ankimon-Api-Key headers. There's no account system
+// behind this yet (v1 matches the addon's existing leaderboard feature,
+// which is also just "well-formed credentials", not a verified identity) -
+// this exists to keep accidental/anonymous traffic out, not to authenticate.
+func requireCredentials(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/healthz" {
+			next.ServeHTTP(w, r)
+			return
+		}
+		username := strings.TrimSpace(r.Header.Get("X-Ankimon-Username"))
+		apiKey := strings.TrimSpace(r.Header.Get("X-Ankimon-Api-Key"))
+		if username == "" || apiKey == "" {
+			writeJSON(w, http.StatusUnauthorized, map[string]string{
+				"error": "X-Ankimon-Username and X-Ankimon-Api-Key headers are required",
+			})
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func writeJSON(w http.ResponseWriter, status int, body interface{}) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(body)
+}

--- a/raid-server/main.go
+++ b/raid-server/main.go
@@ -1,12 +1,17 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"log"
 	"net/http"
 	"os"
 	"strings"
 )
+
+type contextKey string
+
+const usernameContextKey contextKey = "ankimon-username"
 
 func main() {
 	port := os.Getenv("PORT")
@@ -25,10 +30,16 @@ func main() {
 }
 
 // requireCredentials enforces that every request carries non-empty
-// X-Ankimon-Username / X-Ankimon-Api-Key headers. There's no account system
-// behind this yet (v1 matches the addon's existing leaderboard feature,
-// which is also just "well-formed credentials", not a verified identity) -
-// this exists to keep accidental/anonymous traffic out, not to authenticate.
+// X-Ankimon-Username / X-Ankimon-Api-Key headers, and stashes the
+// authenticated username in the request context so handlers use *that*
+// identity - never a "username" field from the request body, which a
+// client could set to impersonate someone else.
+//
+// There's no account system behind this yet (v1 matches the addon's
+// existing leaderboard feature, which is also just "well-formed
+// credentials", not a verified identity) - this exists to keep
+// accidental/anonymous traffic out and to bind every action to the caller
+// who authenticated it, not to cryptographically verify who they are.
 func requireCredentials(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/healthz" {
@@ -43,8 +54,14 @@ func requireCredentials(next http.Handler) http.Handler {
 			})
 			return
 		}
-		next.ServeHTTP(w, r)
+		ctx := context.WithValue(r.Context(), usernameContextKey, username)
+		next.ServeHTTP(w, r.WithContext(ctx))
 	})
+}
+
+func authenticatedUsername(r *http.Request) string {
+	username, _ := r.Context().Value(usernameContextKey).(string)
+	return username
 }
 
 func writeJSON(w http.ResponseWriter, status int, body interface{}) {

--- a/raid-server/raid.go
+++ b/raid-server/raid.go
@@ -1,0 +1,169 @@
+package main
+
+import (
+	"errors"
+	"math/rand"
+	"sync"
+	"time"
+)
+
+var (
+	ErrRaidNotFound     = errors.New("raid not found")
+	ErrRaidAlreadyOver  = errors.New("raid boss already defeated")
+	ErrParticipantEmpty = errors.New("username is required")
+)
+
+// Participant tracks one trainer's contribution to a raid.
+type Participant struct {
+	Username    string    `json:"username"`
+	DamageDealt int       `json:"damage_dealt"`
+	JoinedAt    time.Time `json:"joined_at"`
+}
+
+// Raid is a shared boss fight. All mutation goes through Store's methods,
+// which hold Store.mu for the duration - Raid itself has no independent lock.
+type Raid struct {
+	ID           string                  `json:"id"`
+	BossName     string                  `json:"boss_name"`
+	BossLevel    int                     `json:"boss_level"`
+	MaxHP        int                     `json:"max_hp"`
+	HP           int                     `json:"hp"`
+	CreatedAt    time.Time               `json:"created_at"`
+	Participants map[string]*Participant `json:"participants"`
+}
+
+func (r *Raid) IsDefeated() bool {
+	return r.HP <= 0
+}
+
+// Store holds all active raids in memory, guarded by a single RWMutex.
+// Good enough for the expected scale (a handful of concurrent raids with a
+// few dozen participants each) - not intended to survive a process restart.
+type Store struct {
+	mu    sync.RWMutex
+	raids map[string]*Raid
+}
+
+func NewStore() *Store {
+	return &Store{raids: make(map[string]*Raid)}
+}
+
+func newRaidID() string {
+	const alphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789" // no 0/O/1/I to avoid confusion when shared verbally
+	b := make([]byte, 6)
+	for i := range b {
+		b[i] = alphabet[rand.Intn(len(alphabet))]
+	}
+	return string(b)
+}
+
+func (s *Store) CreateRaid(bossName string, bossLevel, maxHP int) *Raid {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if maxHP <= 0 {
+		maxHP = 1
+	}
+
+	var id string
+	for {
+		id = newRaidID()
+		if _, exists := s.raids[id]; !exists {
+			break
+		}
+	}
+
+	raid := &Raid{
+		ID:           id,
+		BossName:     bossName,
+		BossLevel:    bossLevel,
+		MaxHP:        maxHP,
+		HP:           maxHP,
+		CreatedAt:    time.Now(),
+		Participants: make(map[string]*Participant),
+	}
+	s.raids[id] = raid
+	return raid
+}
+
+// ListActive returns all raids whose boss hasn't been defeated yet.
+func (s *Store) ListActive() []*Raid {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	active := make([]*Raid, 0, len(s.raids))
+	for _, r := range s.raids {
+		if !r.IsDefeated() {
+			active = append(active, r)
+		}
+	}
+	return active
+}
+
+func (s *Store) Get(id string) (*Raid, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	raid, ok := s.raids[id]
+	if !ok {
+		return nil, ErrRaidNotFound
+	}
+	return raid, nil
+}
+
+func (s *Store) Join(id, username string) (*Raid, error) {
+	if username == "" {
+		return nil, ErrParticipantEmpty
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	raid, ok := s.raids[id]
+	if !ok {
+		return nil, ErrRaidNotFound
+	}
+	if _, already := raid.Participants[username]; !already {
+		raid.Participants[username] = &Participant{
+			Username: username,
+			JoinedAt: time.Now(),
+		}
+	}
+	return raid, nil
+}
+
+// Attack applies clamped damage from one participant's move to the raid boss.
+// See maxPossibleDamage for why the claimed damage is clamped rather than
+// trusted outright.
+func (s *Store) Attack(id, username string, claimedDamage int, level, basePower, atkStat, defStat int) (*Raid, int, error) {
+	if username == "" {
+		return nil, 0, ErrParticipantEmpty
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	raid, ok := s.raids[id]
+	if !ok {
+		return nil, 0, ErrRaidNotFound
+	}
+	if raid.IsDefeated() {
+		return nil, 0, ErrRaidAlreadyOver
+	}
+
+	participant, joined := raid.Participants[username]
+	if !joined {
+		participant = &Participant{Username: username, JoinedAt: time.Now()}
+		raid.Participants[username] = participant
+	}
+
+	dmg := clampDamage(claimedDamage, level, basePower, atkStat, defStat)
+
+	raid.HP -= dmg
+	if raid.HP < 0 {
+		raid.HP = 0
+	}
+	participant.DamageDealt += dmg
+
+	return raid, dmg, nil
+}

--- a/raid-server/raid_test.go
+++ b/raid-server/raid_test.go
@@ -1,0 +1,153 @@
+package main
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestCreateRaidDefaultsAndGet(t *testing.T) {
+	store := NewStore()
+	raid := store.CreateRaid("Rayquaza", 70, 500)
+
+	if raid.HP != 500 || raid.MaxHP != 500 {
+		t.Fatalf("expected HP/MaxHP to start at 500, got HP=%d MaxHP=%d", raid.HP, raid.MaxHP)
+	}
+	if raid.ID == "" {
+		t.Fatal("expected a non-empty raid ID")
+	}
+
+	got, err := store.Get(raid.ID)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ID != raid.ID {
+		t.Fatalf("expected to fetch the same raid back, got a different one")
+	}
+}
+
+func TestCreateRaidRejectsNonPositiveMaxHP(t *testing.T) {
+	store := NewStore()
+	raid := store.CreateRaid("Groudon", 60, 0)
+	if raid.MaxHP != 1 || raid.HP != 1 {
+		t.Fatalf("expected non-positive max_hp to be clamped to 1, got %d", raid.MaxHP)
+	}
+}
+
+func TestGetUnknownRaid(t *testing.T) {
+	store := NewStore()
+	if _, err := store.Get("does-not-exist"); err != ErrRaidNotFound {
+		t.Fatalf("expected ErrRaidNotFound, got %v", err)
+	}
+}
+
+func TestJoinAddsParticipantOnce(t *testing.T) {
+	store := NewStore()
+	raid := store.CreateRaid("Kyogre", 60, 300)
+
+	if _, err := store.Join(raid.ID, "ash"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := store.Join(raid.ID, "ash"); err != nil {
+		t.Fatalf("unexpected error joining twice: %v", err)
+	}
+
+	got, _ := store.Get(raid.ID)
+	if len(got.Participants) != 1 {
+		t.Fatalf("expected exactly 1 participant after joining twice, got %d", len(got.Participants))
+	}
+}
+
+func TestJoinRejectsEmptyUsername(t *testing.T) {
+	store := NewStore()
+	raid := store.CreateRaid("Kyogre", 60, 300)
+	if _, err := store.Join(raid.ID, ""); err != ErrParticipantEmpty {
+		t.Fatalf("expected ErrParticipantEmpty, got %v", err)
+	}
+}
+
+func TestAttackClampsAbsurdDamageClaim(t *testing.T) {
+	store := NewStore()
+	raid := store.CreateRaid("Mewtwo", 70, 1000)
+
+	// A claimed 999999 damage from a level 5, 40-base-power move must be
+	// clamped down to a physically-plausible ceiling, not applied as-is.
+	_, accepted, err := store.Attack(raid.ID, "cheater", 999999, 5, 40, 20, 20)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if accepted >= 999999 {
+		t.Fatalf("expected damage to be clamped, got %d accepted", accepted)
+	}
+
+	got, _ := store.Get(raid.ID)
+	if got.HP != 1000-accepted {
+		t.Fatalf("expected raid HP to drop by exactly the accepted damage, got HP=%d accepted=%d", got.HP, accepted)
+	}
+}
+
+func TestAttackReasonableDamagePassesThrough(t *testing.T) {
+	store := NewStore()
+	raid := store.CreateRaid("Mewtwo", 70, 1000)
+
+	_, accepted, err := store.Attack(raid.ID, "trainer", 15, 20, 40, 50, 40)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if accepted != 15 {
+		t.Fatalf("expected a reasonable damage claim to pass through unclamped, got %d", accepted)
+	}
+}
+
+func TestAttackOnDefeatedRaidFails(t *testing.T) {
+	store := NewStore()
+	raid := store.CreateRaid("Deoxys", 50, 10)
+
+	if _, _, err := store.Attack(raid.ID, "trainer", 10, 50, 40, 40, 10); err != nil {
+		t.Fatalf("unexpected error on defeating hit: %v", err)
+	}
+	got, _ := store.Get(raid.ID)
+	if !got.IsDefeated() {
+		t.Fatalf("expected raid to be defeated, HP=%d", got.HP)
+	}
+
+	if _, _, err := store.Attack(raid.ID, "trainer", 10, 50, 40, 40, 10); err != ErrRaidAlreadyOver {
+		t.Fatalf("expected ErrRaidAlreadyOver, got %v", err)
+	}
+}
+
+func TestListActiveExcludesDefeatedRaids(t *testing.T) {
+	store := NewStore()
+	alive := store.CreateRaid("Alive", 50, 100)
+	dead := store.CreateRaid("Dead", 50, 5)
+	store.Attack(dead.ID, "trainer", 999, 50, 40, 40, 10)
+
+	active := store.ListActive()
+	if len(active) != 1 || active[0].ID != alive.ID {
+		t.Fatalf("expected only the alive raid to be listed, got %d raids", len(active))
+	}
+}
+
+func TestConcurrentAttacksDoNotRace(t *testing.T) {
+	store := NewStore()
+	raid := store.CreateRaid("Groudon", 60, 100000)
+
+	const goroutines = 50
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func(n int) {
+			defer wg.Done()
+			store.Attack(raid.ID, "trainer", 10, 50, 40, 40, 10)
+		}(i)
+	}
+	wg.Wait()
+
+	got, _ := store.Get(raid.ID)
+	totalDamage := 0
+	for _, p := range got.Participants {
+		totalDamage += p.DamageDealt
+	}
+	if got.HP != 100000-totalDamage {
+		t.Fatalf("HP (%d) doesn't match total tracked damage (%d) - lost updates under concurrency", got.HP, totalDamage)
+	}
+}

--- a/src/Ankimon/__init__.py
+++ b/src/Ankimon/__init__.py
@@ -66,6 +66,7 @@ try:
     from .functions.badges_functions import *
     from .functions.battle_functions import *
     from .functions import battle_engine
+    from .functions import raid_functions
     from .functions.pokemon_functions import *
     from .functions.create_gui_functions import *
     from .functions.create_css_for_reviewer import create_css_for_reviewer
@@ -269,6 +270,12 @@ ankimon_tracker_obj = AnkimonTracker(
 # Set Pokémon in the tracker
 ankimon_tracker_obj.set_main_pokemon(main_pokemon)
 ankimon_tracker_obj.set_enemy_pokemon(enemy_pokemon)
+
+# Raid session tracks whether we're currently in a shared boss fight - see
+# pyobj/raid_obj.py and functions/raid_functions.py (talks to raid-server/).
+from .pyobj.raid_obj import RaidSession
+raid_session_obj = RaidSession()
+mw.raid_session_obj = raid_session_obj
 
 # Initialize the Pokémon Shop Manager
 shop_manager = PokemonShopManager(
@@ -1799,6 +1806,18 @@ def on_review_card(*args):
                                 battle_status, slp_counter = battle_engine.apply_secondary_status(move, battle_status, slp_counter)
                                 if dmg == 0:
                                     msg += "\n" + translator.translate("move_has_missed")
+                                if raid_session_obj.active and dmg > 0:
+                                    raid_functions.try_send_attack(
+                                        raid_session_obj.raid_id, dmg, main_pokemon.level,
+                                        move["basePower"], atk_stat, def_stat)
+                                    raid_session_obj.note_card_reviewed()
+                                    if raid_session_obj.should_poll():
+                                        try:
+                                            raid_session_obj.apply_state(raid_functions.poll_raid_state(raid_session_obj.raid_id))
+                                        except raid_functions.RaidClientError as e:
+                                            logger.log_and_showinfo("error", f"Raid state poll failed: {e}")
+                                        finally:
+                                            raid_session_obj.note_polled()
                         except Exception as e:
                             logger.log_and_showinfo("error", f"Player attack resolution failed, falling back to a generic attack: {e}")
                             if category == "Special":

--- a/src/Ankimon/__init__.py
+++ b/src/Ankimon/__init__.py
@@ -65,6 +65,7 @@ try:
     from .functions.pokedex_functions import *
     from .functions.badges_functions import *
     from .functions.battle_functions import *
+    from .functions import battle_engine
     from .functions.pokemon_functions import *
     from .functions.create_gui_functions import *
     from .functions.create_css_for_reviewer import create_css_for_reviewer
@@ -1639,7 +1640,7 @@ def on_review_card(*args):
         if ankimon_tracker_obj.cards_battle_round >= int(settings_obj.get("battle.cards_per_round", 2)):
             ankimon_tracker_obj.cards_battle_round = 0
             ankimon_tracker_obj.attack_counter = 0
-            slp_counter = 0
+            slp_counter = ankimon_tracker_obj.slp_counter
             ankimon_tracker_obj.pokemon_encouter += 1
             multiplier = int(ankimon_tracker_obj.multiplier)
             msg = ""
@@ -1667,7 +1668,9 @@ def on_review_card(*args):
                     else:
                         if e_move_category == "Status":
                             color = "#F7DC6F"
-                            msg = effect_status_moves(rand_enemy_atk, enemy_pokemon.stats, main_pokemon.stats, msg, main_pokemon.name , enemy_pokemon.name)
+                            msg, battle_status, slp_counter = battle_engine.resolve_status_move(
+                                rand_enemy_atk, enemy_pokemon.stats, main_pokemon.stats,
+                                enemy_pokemon.name, main_pokemon.name, msg, battle_status, slp_counter)
                         elif e_move_category == "Physical" or e_move_category == "Special":
                             critRatio = enemy_move.get("critRatio", 1)
                             if e_move_category == "Physical":
@@ -1697,14 +1700,18 @@ def on_review_card(*args):
                                 else:
                                     reviewer_obj.myseconds = 0
                                 msg += translator.translate("dmg_dealt", dmg=enemy_dmg, pokemon_name=main_pokemon.name.capitalize())
-                except:
+                except Exception as e:
+                    logger.log_and_showinfo("error", f"Enemy attack resolution failed, falling back to a generic attack: {e}")
                     enemy_dmg = 0
                     rand_enemy_atk = random.choice(enemy_pokemon.attacks)
                     enemy_move = find_details_move(rand_enemy_atk)
                     e_move_category = enemy_move.get("category")
+                    critRatio = enemy_move.get("critRatio", 1)
                     if e_move_category == "Status":
                             color = "#F7DC6F"
-                            msg = effect_status_moves(rand_enemy_atk, enemy_pokemon.stats, main_pokemon.stats, msg, main_pokemon.name , enemy_pokemon.name)
+                            msg, battle_status, slp_counter = battle_engine.resolve_status_move(
+                                rand_enemy_atk, enemy_pokemon.stats, main_pokemon.stats,
+                                enemy_pokemon.name, main_pokemon.name, msg, battle_status, slp_counter)
                     elif e_move_category == "Physical" or e_move_category == "Special":
                         if e_move_category == "Special":
                             def_stat = main_pokemon.stats["spd"]
@@ -1739,7 +1746,7 @@ def on_review_card(*args):
                 category = move.get("category")
                 acc = move.get("accuracy")
                 if battle_status != "fighting":
-                    msg, acc, battle_status, enemy_pokemon.stats = status_effect(enemy_pokemon, move, slp_counter, msg, acc)
+                    msg, acc, battle_status, enemy_pokemon.stats = battle_engine.resolve_status_effect(enemy_pokemon, move, slp_counter, msg, acc)
                 if acc is True:
                     acc = 100
                 if acc != 0:
@@ -1761,10 +1768,12 @@ def on_review_card(*args):
                 else:
                     if category == "Status":
                         color = "#F7DC6F"
-                        msg = effect_status_moves(random_attack, main_pokemon.stats, enemy_pokemon.stats, msg, enemy_pokemon.name, main_pokemon.name)
+                        msg, battle_status, slp_counter = battle_engine.resolve_status_move(
+                            random_attack, main_pokemon.stats, enemy_pokemon.stats,
+                            main_pokemon.name, enemy_pokemon.name, msg, battle_status, slp_counter)
                     elif category == "Physical" or category == "Special":
+                        critRatio = move.get("critRatio", 1)
                         try:
-                            critRatio = move.get("critRatio", 1)
                             if category == "Physical":
                                 color = "#F0B27A"
                             elif category == "Special":
@@ -1787,17 +1796,11 @@ def on_review_card(*args):
                                     dmg = 1
                                 enemy_pokemon.hp -= dmg
                                 msg += translator.translate("dmg_dealt", dmg=dmg, pokemon_name=enemy_pokemon.name.capitalize())
-                                move_stat = move.get("status", None)
-                                secondary = move.get("secondary", None)
-                                if secondary is not None:
-                                    bat_status = move.get("secondary", None).get("status", None)
-                                    if bat_status is not None:
-                                        move_with_status(move, move_stat, secondary)
-                                if move_stat is not None:
-                                    move_with_status(move, move_stat, secondary)
+                                battle_status, slp_counter = battle_engine.apply_secondary_status(move, battle_status, slp_counter)
                                 if dmg == 0:
                                     msg += "\n" + translator.translate("move_has_missed")
-                        except:
+                        except Exception as e:
+                            logger.log_and_showinfo("error", f"Player attack resolution failed, falling back to a generic attack: {e}")
                             if category == "Special":
                                 def_stat = enemy_pokemon.stats["spd"]
                                 atk_stat = main_pokemon.stats["spa"]
@@ -1821,6 +1824,11 @@ def on_review_card(*args):
                             play_effect_sound("HurtSuper")
                     else:
                         reviewer_obj.seconds = 0
+
+            # Persist status/sleep-counter so they carry over into the next round,
+            # instead of silently resetting every time on_review_card runs.
+            ankimon_tracker_obj.slp_counter = slp_counter
+            enemy_pokemon.battle_status = battle_status
 
             if enemy_pokemon.hp < 1:
                 enemy_pokemon.hp = 0
@@ -1875,65 +1883,10 @@ def on_review_card(*args):
     except Exception as e:
         showWarning(f"An error occurred in reviewer: {str(e)}")
 
-def effect_status_moves(move_name, mainpokemon_stats, stats, msg, name, mainpokemon_name):
-    global battle_status
-    move = find_details_move(move_name)
-    target = move.get("target")
-    boosts = move.get("boosts", {})
-    stat_boost_value = {
-        "hp": boosts.get("hp", 0),
-        "atk": boosts.get("atk", 0),
-        "def": boosts.get("def", 0),
-        "spa": boosts.get("spa", 0),
-        "spd": boosts.get("spd", 0),
-        "spe": boosts.get("spe", 0),
-        "xp": mainpokemon_stats.get("xp", 0)
-    }
-    move_stat = move.get("status",None)
-    status = move.get("secondary",None)
-    if move_stat is not None:
-        battle_status = move_stat
-    if status is not None:
-        random_number = random.random()
-        chances = status["chance"] / 100
-        if random_number < chances:
-            battle_status = status["status"]
-    if battle_status == "slp":
-        slp_counter = random.randint(1, 3)
-    if target == "self":
-        for boost, stage in boosts.items():
-            stat = get_multiplier_stats(stage)
-            mainpokemon_stats[boost] = mainpokemon_stats.get(boost, 0) * stat
-            msg += f" {main_pokemon.name.capitalize()}'s "
-            if stage < 0:
-                msg += f"{boost.capitalize()} {translator.translate('stat_decreased')}."
-            elif stage > 0:
-                msg += f"{boost.capitalize()} {translator.translate('stat_increased')}."
-    elif target in ["normal", "allAdjacentFoes"]:
-        for boost, stage in boosts.items():
-            stat = get_multiplier_stats(stage)
-            stats[boost] = stats.get(boost, 0) * stat
-            msg += f" {name.capitalize()}'s "
-            if stage < 0:
-                msg += f"{boost.capitalize()} {translator.translate('stat_decreased')}."
-            elif stage > 0:
-                msg += f"{boost.capitalize()} {translator.translate('stat_increased')}."
-    return msg
-
-def move_with_status(move, move_stat, status):
-    global battle_status
-    target = move.get("target")
-    bat_status = move.get("secondary", None).get("status", None)
-    if target in ["normal", "allAdjacentFoes"]:
-        if move_stat is not None:
-            battle_status = move_stat
-        if status is not None:
-            random_number = random.random()
-            chances = status["chance"] / 100
-            if random_number < chances:
-                battle_status = status["status"]
-    if battle_status == "slp":
-        slp_counter = random.randint(1, 3)
+## effect_status_moves / move_with_status were replaced by
+## functions.battle_engine.resolve_status_move / apply_secondary_status,
+## which thread battle_status/slp_counter explicitly instead of relying on
+## module globals that on_review_card's local variables never actually saw.
 
 # Connect the hook to Anki's review event
 gui_hooks.reviewer_did_answer_card.append(on_review_card)

--- a/src/Ankimon/business.py
+++ b/src/Ankimon/business.py
@@ -75,13 +75,14 @@ def get_multiplier_acc_eva(stage):
     return stage_to_factor_new.get(stage, "Invalid stage")
 
 def bP_none_moves(move):
-    target =  move.get("target", None)
+    target = move.get("target", None)
     if target == "normal":
         damage = move.get("damage")
         if damage is None:
             damage = 5
         return damage
-    
+    return 0
+
 def type_colors(type):
     type_colors = {
         "Normal": "#A8A77A",

--- a/src/Ankimon/functions/battle_engine.py
+++ b/src/Ankimon/functions/battle_engine.py
@@ -1,0 +1,104 @@
+"""Pure, Anki-independent battle resolution logic.
+
+Extracted from the reviewer hook in ``__init__.py`` so the damage/status
+math can be unit tested without mocking Qt/Anki. No ``aqt``/``global``
+state here on purpose - callers own and thread their own state
+(``battle_status``, ``slp_counter``) through these functions.
+"""
+import random
+
+from .battle_functions import calc_atk_dmg, get_effectiveness, status_effect
+from .pokedex_functions import find_details_move
+from ..business import get_multiplier_stats, bP_none_moves
+
+
+def resolve_status_effect(pokemon_obj, move, slp_counter, msg, acc):
+    """Apply an active battle status (par/brn/psn/tox/frz/slp) before a move resolves.
+
+    Thin wrapper around ``battle_functions.status_effect`` - kept here so
+    all battle-round logic has one entry point.
+    """
+    return status_effect(pokemon_obj, move, slp_counter, msg, acc)
+
+
+def resolve_status_move(move_name, actor_stats, target_stats, actor_name, target_name,
+                         msg, battle_status, slp_counter):
+    """Apply a status move's stat boosts / inflicted status.
+
+    Returns (msg, battle_status, slp_counter). ``actor_stats``/``target_stats``
+    are mutated in place (same as the legacy behaviour), matching how the
+    caller mutates ``PokemonObject.stats`` dicts today.
+    """
+    move = find_details_move(move_name)
+    target = move.get("target")
+    boosts = move.get("boosts", {}) or {}
+    move_stat = move.get("status", None)
+    secondary = move.get("secondary", None)
+
+    if move_stat is not None:
+        battle_status = move_stat
+    if secondary is not None:
+        secondary_status = secondary.get("status")
+        if secondary_status is not None and random.random() < secondary.get("chance", 0) / 100:
+            battle_status = secondary_status
+    if battle_status == "slp":
+        slp_counter = random.randint(1, 3)
+
+    if target == "self":
+        for boost, stage in boosts.items():
+            multiplier = get_multiplier_stats(stage)
+            actor_stats[boost] = actor_stats.get(boost, 0) * multiplier
+            msg += f" {actor_name.capitalize()}'s "
+            if stage < 0:
+                msg += f"{boost.capitalize()} decreased."
+            elif stage > 0:
+                msg += f"{boost.capitalize()} increased."
+    elif target in ("normal", "allAdjacentFoes"):
+        for boost, stage in boosts.items():
+            multiplier = get_multiplier_stats(stage)
+            target_stats[boost] = target_stats.get(boost, 0) * multiplier
+            msg += f" {target_name.capitalize()}'s "
+            if stage < 0:
+                msg += f"{boost.capitalize()} decreased."
+            elif stage > 0:
+                msg += f"{boost.capitalize()} increased."
+
+    return msg, battle_status, slp_counter
+
+
+def apply_secondary_status(move, battle_status, slp_counter):
+    """Roll a damaging move's secondary status-inflict chance, if any.
+
+    Returns (battle_status, slp_counter).
+    """
+    move_stat = move.get("status", None)
+    secondary = move.get("secondary", None)
+    if secondary is None:
+        return battle_status, slp_counter
+
+    target = move.get("target")
+    secondary_status = secondary.get("status")
+    if target in ("normal", "allAdjacentFoes"):
+        if move_stat is not None:
+            battle_status = move_stat
+        if secondary_status is not None and random.random() < secondary.get("chance", 0) / 100:
+            battle_status = secondary_status
+    if battle_status == "slp":
+        slp_counter = random.randint(1, 3)
+
+    return battle_status, slp_counter
+
+
+def resolve_damage_move(move, level, multiplier, atk_stat, def_stat, attacker_type, defender_type, critRatio=1):
+    """Compute damage for a Physical/Special move, including the base-power-less case.
+
+    Returns the integer damage dealt (>= 0). Callers are responsible for
+    clamping a landed hit to a minimum of 1 damage, matching existing
+    battle-round behaviour.
+    """
+    base_power = move.get("basePower", 0)
+    if not base_power:
+        return int(bP_none_moves(move))
+    move_type = move.get("type", "Normal")
+    return int(calc_atk_dmg(level, multiplier, base_power, atk_stat, def_stat,
+                             attacker_type, move_type, defender_type, critRatio))

--- a/src/Ankimon/functions/battle_functions.py
+++ b/src/Ankimon/functions/battle_functions.py
@@ -50,7 +50,10 @@ def calc_atk_dmg(level, critical, power, stat_atk, wild_stat_def, main_type, mov
             critical = critical * 1
         else:
             critical += 2
-        stab = 1.5 if move_type == main_type else 1.0
+        # main_type is a list (e.g. ["Grass"]) and move_type a bare string (e.g. "grass") -
+        # comparing them directly (`move_type == main_type`) never matched, so STAB never applied.
+        main_types = [main_type] if isinstance(main_type, str) else main_type
+        stab = 1.5 if move_type.capitalize() in [t.capitalize() for t in main_types] else 1.0
         eff = get_effectiveness(move_type, wild_type)
         # random luck
         random_number = random.randint(217, 255)
@@ -97,16 +100,19 @@ def status_effect(pokemon_obj, move, slp_counter, msg, acc):
         msg += (f"The wild {name} is badly poisoned and was hurt by is poisoning!")
         stat = "psn"
     elif stat == "frz":
-        free_chance = 20 / 100
+        # NOTE: this used to be inverted - `random_number < free_chance` was
+        # treated as "stays frozen", so a fire move (free_chance forced to 1)
+        # almost always kept the target frozen instead of always thawing it.
+        thaw_chance = 20 / 100
         if move["type"] == "fire" and move["target"] != "self":
-            free_chance = 1
+            thaw_chance = 1
         random_number = random.random()
-        if random_number < free_chance:
-            msg += (f"Wild {name} is frozen solid!")
-            acc = 0
-        else:
+        if random_number < thaw_chance:
             stat = None
             msg += (f"Wild {name} is no longer frozen!")
+        else:
+            msg += (f"Wild {name} is frozen solid!")
+            acc = 0
     elif stat == "slp":
             if slp_counter > 1:
                 slp_counter -= 1
@@ -114,4 +120,7 @@ def status_effect(pokemon_obj, move, slp_counter, msg, acc):
             else:
                 stat = None
                 msg += (f"Wild {name} is no longer asleep!")
-    return msg, acc, stat, battle_stats
+    # brn/psn/tox above compute damage-over-time into `hp` - persist it back
+    # onto the Pokemon (it used to be discarded, making status DOT a no-op).
+    pokemon_obj.hp = max(0, int(hp))
+    return msg, acc, stat, stats

--- a/src/Ankimon/functions/raid_functions.py
+++ b/src/Ankimon/functions/raid_functions.py
@@ -1,0 +1,126 @@
+"""HTTP client for the raid-server relay (see raid-server/ at the repo root).
+
+Follows the same shape as pyobj/ankimon_leaderboard.py: read credentials
+from user_path_credentials, respect a settings toggle, use `requests`
+directly, and surface failures via showInfo/logger instead of silently
+swallowing them.
+"""
+import json
+
+import requests
+from aqt import mw
+from aqt.utils import showInfo
+
+from ..resources import user_path_credentials
+
+
+class RaidClientError(Exception):
+    """Raised when a raid-server request fails or credentials are missing."""
+
+
+def _server_url():
+    return mw.settings_obj.get("raid.server_url", "http://localhost:8080").rstrip("/")
+
+
+def _auth_headers():
+    try:
+        with open(user_path_credentials, "r", encoding="utf-8") as f:
+            credentials = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        raise RaidClientError(
+            "No Ankimon credentials found. Set them up from the Ankimon menu "
+            "(the same credentials used for the leaderboard) before joining a raid."
+        )
+
+    username = credentials.get("username")
+    api_key = credentials.get("api_key")
+    if not username or not api_key:
+        raise RaidClientError(
+            "Missing username/api_key in Ankimon credentials. Set them up from the Ankimon menu."
+        )
+
+    return username, {
+        "X-Ankimon-Username": username,
+        "X-Ankimon-Api-Key": api_key,
+        "Content-Type": "application/json",
+    }
+
+
+def _request(method, path, json_body=None):
+    if not mw.settings_obj.get("raid.enabled", False):
+        raise RaidClientError("Raids are disabled. Enable them in Ankimon settings first.")
+
+    _, headers = _auth_headers()
+    url = f"{_server_url()}{path}"
+    try:
+        response = requests.request(method, url, headers=headers, json=json_body, timeout=10)
+    except requests.exceptions.RequestException as e:
+        raise RaidClientError(f"Couldn't reach the raid server at {url}: {e}")
+
+    if response.status_code >= 400:
+        try:
+            detail = response.json().get("error", response.text)
+        except ValueError:
+            detail = response.text
+        raise RaidClientError(f"Raid server error ({response.status_code}): {detail}")
+
+    try:
+        return response.json()
+    except ValueError:
+        raise RaidClientError("Raid server returned an unexpected (non-JSON) response.")
+
+
+def create_raid(boss_name, boss_level, max_hp):
+    """Create a new raid boss on the server. Returns the raid state dict."""
+    return _request("POST", "/raids", {
+        "boss_name": boss_name,
+        "boss_level": boss_level,
+        "max_hp": max_hp,
+    })
+
+
+def list_active_raids():
+    """Return the list of raids whose boss hasn't been defeated yet."""
+    return _request("GET", "/raids")
+
+
+def poll_raid_state(raid_id):
+    """Fetch the current state of one raid (boss HP, participants)."""
+    return _request("GET", f"/raids/{raid_id}")
+
+
+def join_raid(raid_id):
+    # No "username" field in the body - the server takes the participant's
+    # identity from the authenticated X-Ankimon-Username header, so a
+    # request body can't claim to act as someone else.
+    return _request("POST", f"/raids/{raid_id}/join", {})
+
+
+def send_attack(raid_id, damage, level, base_power, atk_stat, def_stat):
+    """Report a locally-computed hit against the raid boss.
+
+    The server clamps `damage` to a plausibility ceiling derived from the
+    other fields (see raid-server/damage.go) - it isn't trusted outright.
+    Returns the server's response, whose `damage_accepted` field is what was
+    actually applied.
+    """
+    return _request("POST", f"/raids/{raid_id}/attack", {
+        "damage": int(damage),
+        "level": int(level),
+        "base_power": int(base_power),
+        "atk_stat": int(atk_stat),
+        "def_stat": int(def_stat),
+    })
+
+
+def try_send_attack(raid_id, damage, level, base_power, atk_stat, def_stat):
+    """Best-effort version of send_attack() for the reviewer hot path.
+
+    A raid hiccup shouldn't break the local solo-battle flow, so this logs
+    and returns None instead of raising.
+    """
+    try:
+        return send_attack(raid_id, damage, level, base_power, atk_stat, def_stat)
+    except RaidClientError as e:
+        mw.logger.log_and_showinfo("error", f"Raid attack failed to sync: {e}")
+        return None

--- a/src/Ankimon/menu_buttons.py
+++ b/src/Ankimon/menu_buttons.py
@@ -8,6 +8,7 @@ from PyQt6.QtGui import QAction, QKeySequence
 # own scripts 
 from .pyobj.trainer_card_window import TrainerCardGUI
 from .pyobj.ankimon_leaderboard import show_api_key_dialog
+from .pyobj.raid_dialog import RaidDialog
 from .gui_classes.choose_trainer_sprite import TrainerSpriteDialog
 from .gui_classes.pokemon_team_window import PokemonTeamDialog
 from .gui_classes.check_files import FileCheckerApp
@@ -209,6 +210,14 @@ def create_menu_actions(
     leaderboard_button.setMenuRole(QAction.MenuRole.NoRole)
     leaderboard_button.triggered.connect(open_leaderboard_url)
     game_menu.addAction(leaderboard_button)
+
+    # Button: Open Raid Battle dialog
+    raid_button = QAction(
+        "Raid Battle", mw
+    )
+    raid_button.setMenuRole(QAction.MenuRole.NoRole)
+    raid_button.triggered.connect(lambda: RaidDialog(mw.raid_session_obj).exec())
+    game_menu.addAction(raid_button)
 
     # Button: Show credits
     credits_button = QAction(

--- a/src/Ankimon/pyobj/pokemon_obj.py
+++ b/src/Ankimon/pyobj/pokemon_obj.py
@@ -64,12 +64,14 @@ class PokemonObject:
         self._update_battle_stats()
 
     def _update_battle_stats(self):
-        """Update battle stats with current stats, EVs, and IVs."""
-        self._battle_stats = {}
-        # Only update battle stats with valid keys
-        for d in [self.stats, self.iv, self.ev]:
-            for key, value in d.items():
-                self._battle_stats[key] = value
+        """Snapshot the current working stats for in-battle modification (stat stages, status).
+
+        Previously this merged self.stats/self.iv/self.ev by overwriting the
+        same keys in that order, so it silently ended up equal to `self.ev`
+        (the last dict in the loop) instead of the actual stats - e.g.
+        paralysis speed reduction was operating on an EV value, not Speed.
+        """
+        self._battle_stats = dict(self.stats)
 
     def calculate_max_hp(self):
         ev_value = self.ev["hp"] / 4

--- a/src/Ankimon/pyobj/raid_dialog.py
+++ b/src/Ankimon/pyobj/raid_dialog.py
@@ -1,0 +1,155 @@
+from PyQt6.QtWidgets import (
+    QDialog, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit, QSpinBox,
+    QPushButton, QListWidget, QProgressBar, QTabWidget, QWidget, QMessageBox,
+)
+from aqt import mw
+
+from ..functions import raid_functions
+from ..functions.raid_functions import RaidClientError
+
+
+class RaidDialog(QDialog):
+    def __init__(self, raid_session, parent=mw):
+        super().__init__(parent)
+        self.raid_session = raid_session
+
+        self.setWindowTitle("Ankimon Raid")
+        self.setMinimumWidth(420)
+
+        layout = QVBoxLayout(self)
+
+        self.tabs = QTabWidget()
+        layout.addWidget(self.tabs)
+
+        self.tabs.addTab(self._build_create_tab(), "Create")
+        self.tabs.addTab(self._build_join_tab(), "Join")
+
+        self.status_group = QWidget()
+        status_layout = QVBoxLayout(self.status_group)
+        self.status_label = QLabel("Not currently in a raid.")
+        self.hp_bar = QProgressBar()
+        self.hp_bar.setRange(0, 1)
+        self.hp_bar.setValue(0)
+        self.participants_list = QListWidget()
+        status_layout.addWidget(self.status_label)
+        status_layout.addWidget(self.hp_bar)
+        status_layout.addWidget(QLabel("Participants:"))
+        status_layout.addWidget(self.participants_list)
+
+        refresh_row = QHBoxLayout()
+        self.refresh_button = QPushButton("Refresh")
+        self.refresh_button.clicked.connect(self.refresh_status)
+        self.leave_button = QPushButton("Leave raid")
+        self.leave_button.clicked.connect(self.leave_raid)
+        refresh_row.addWidget(self.refresh_button)
+        refresh_row.addWidget(self.leave_button)
+        status_layout.addLayout(refresh_row)
+
+        layout.addWidget(self.status_group)
+
+        self.refresh_status()
+
+    def _build_create_tab(self):
+        tab = QWidget()
+        form = QVBoxLayout(tab)
+
+        self.boss_name_input = QLineEdit()
+        self.boss_name_input.setPlaceholderText("Boss name (e.g. Rayquaza)")
+
+        self.boss_level_input = QSpinBox()
+        self.boss_level_input.setRange(1, 100)
+        self.boss_level_input.setValue(50)
+
+        self.boss_hp_input = QSpinBox()
+        self.boss_hp_input.setRange(1, 100000)
+        self.boss_hp_input.setValue(500)
+
+        create_button = QPushButton("Create raid")
+        create_button.clicked.connect(self.create_raid)
+
+        form.addWidget(QLabel("Boss name"))
+        form.addWidget(self.boss_name_input)
+        form.addWidget(QLabel("Boss level"))
+        form.addWidget(self.boss_level_input)
+        form.addWidget(QLabel("Boss max HP"))
+        form.addWidget(self.boss_hp_input)
+        form.addWidget(create_button)
+        return tab
+
+    def _build_join_tab(self):
+        tab = QWidget()
+        form = QVBoxLayout(tab)
+
+        self.raid_id_input = QLineEdit()
+        self.raid_id_input.setPlaceholderText("Raid ID (shared by whoever created it)")
+
+        join_button = QPushButton("Join raid")
+        join_button.clicked.connect(self.join_raid)
+
+        form.addWidget(QLabel("Raid ID"))
+        form.addWidget(self.raid_id_input)
+        form.addWidget(join_button)
+        return tab
+
+    def create_raid(self):
+        boss_name = self.boss_name_input.text().strip()
+        if not boss_name:
+            QMessageBox.warning(self, "Ankimon Raid", "Enter a boss name first.")
+            return
+        try:
+            raid_state = raid_functions.create_raid(
+                boss_name, self.boss_level_input.value(), self.boss_hp_input.value()
+            )
+            raid_functions.join_raid(raid_state["id"])
+            self.raid_session.start(raid_state)
+            self.refresh_status()
+        except RaidClientError as e:
+            QMessageBox.warning(self, "Ankimon Raid", str(e))
+
+    def join_raid(self):
+        raid_id = self.raid_id_input.text().strip()
+        if not raid_id:
+            QMessageBox.warning(self, "Ankimon Raid", "Enter a raid ID first.")
+            return
+        try:
+            raid_state = raid_functions.join_raid(raid_id)
+            self.raid_session.start(raid_state)
+            self.refresh_status()
+        except RaidClientError as e:
+            QMessageBox.warning(self, "Ankimon Raid", str(e))
+
+    def leave_raid(self):
+        self.raid_session.stop()
+        self.refresh_status()
+
+    def refresh_status(self):
+        if not self.raid_session.active or not self.raid_session.raid_id:
+            self.status_label.setText("Not currently in a raid.")
+            self.hp_bar.setRange(0, 1)
+            self.hp_bar.setValue(0)
+            self.participants_list.clear()
+            return
+
+        try:
+            raid_state = raid_functions.poll_raid_state(self.raid_session.raid_id)
+            self.raid_session.apply_state(raid_state)
+            self.raid_session.note_polled()
+        except RaidClientError as e:
+            self.status_label.setText(f"Couldn't refresh raid state: {e}")
+            return
+
+        defeated = self.raid_session.hp is not None and self.raid_session.hp <= 0
+        state_text = "Defeated!" if defeated else "In progress"
+        self.status_label.setText(
+            f"{self.raid_session.boss_name} (Lv. {self.raid_session.boss_level}) "
+            f"- {self.raid_session.hp}/{self.raid_session.max_hp} HP - {state_text}\n"
+            f"Raid ID: {self.raid_session.raid_id}"
+        )
+        self.hp_bar.setRange(0, self.raid_session.max_hp or 1)
+        self.hp_bar.setValue(max(0, self.raid_session.hp or 0))
+
+        self.participants_list.clear()
+        for participant in self.raid_session.participants.values():
+            self.participants_list.addItem(
+                f"{participant['username']}: {participant['damage_dealt']} damage dealt"
+            )

--- a/src/Ankimon/pyobj/raid_obj.py
+++ b/src/Ankimon/pyobj/raid_obj.py
@@ -1,0 +1,57 @@
+"""Client-side state for an active raid, mirroring the shape of AnkimonTracker.
+
+Owns nothing about HTTP - functions/raid_functions.py does the actual
+server calls. This just tracks "am I in a raid, and what did the server
+last tell me about it" so the reviewer hook and any raid UI can share it.
+"""
+
+
+class RaidSession:
+    def __init__(self):
+        self.active = False
+        self.raid_id = None
+        self.boss_name = None
+        self.boss_level = None
+        self.max_hp = None
+        self.hp = None
+        self.participants = {}
+        self.cards_since_last_poll = 0
+        self.poll_every_n_cards = 5
+
+    def start(self, raid_state):
+        """Begin tracking a raid from a raid-server state dict (as returned
+        by create_raid/join_raid/poll_raid_state)."""
+        self.active = True
+        self.apply_state(raid_state)
+
+    def stop(self):
+        self.active = False
+        self.raid_id = None
+        self.boss_name = None
+        self.boss_level = None
+        self.max_hp = None
+        self.hp = None
+        self.participants = {}
+        self.cards_since_last_poll = 0
+
+    def apply_state(self, raid_state):
+        """Update local tracking from a raid-server state dict."""
+        self.raid_id = raid_state.get("id", self.raid_id)
+        self.boss_name = raid_state.get("boss_name", self.boss_name)
+        self.boss_level = raid_state.get("boss_level", self.boss_level)
+        self.max_hp = raid_state.get("max_hp", self.max_hp)
+        self.hp = raid_state.get("hp", self.hp)
+        self.participants = raid_state.get("participants", self.participants)
+        if self.hp is not None and self.hp <= 0:
+            self.active = False
+
+    def should_poll(self):
+        """Whether enough cards have been reviewed since the last poll to
+        justify refreshing raid state from the server."""
+        return self.active and self.cards_since_last_poll >= self.poll_every_n_cards
+
+    def note_card_reviewed(self):
+        self.cards_since_last_poll += 1
+
+    def note_polled(self):
+        self.cards_since_last_poll = 0

--- a/src/Ankimon/pyobj/settings.py
+++ b/src/Ankimon/pyobj/settings.py
@@ -22,6 +22,12 @@ class Settings:
         if "misc.leaderboard" not in config:
             config["misc.leaderboard"] = False  # Add the new setting with its default value
 
+        # Backfill raid settings for existing configs created before this feature
+        if "raid.enabled" not in config:
+            config["raid.enabled"] = False
+        if "raid.server_url" not in config:
+            config["raid.server_url"] = "http://localhost:8080"
+
         if not config:
             #Card max time in Seconds
             config = {
@@ -69,6 +75,9 @@ class Settings:
                 "misc.ssh": True,
                 "misc.leaderboard": False,
                 "misc.YouShallNotPass_Ankimon_News": False,
+
+                "raid.enabled": False,
+                "raid.server_url": "http://localhost:8080",
                 "misc.discord_rich_presence": False,
                 "misc.discord_rich_presence_text": 1,
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,36 @@
+"""Shared pytest setup for testing addon modules outside a live Anki install.
+
+The addon's ``__init__.py`` wires up real ``aqt``/Anki hooks at import time,
+so a plain ``import Ankimon...`` would require a full Anki environment. The
+modules under test here (``battle_engine``, ``battle_functions``,
+``business``, ``resources``, ``pokedex_functions``) don't actually need
+Anki - they only pull in ``aqt.utils`` for error dialogs on failure paths.
+So: stub out ``aqt`` and register ``Ankimon`` as a namespace package pointed
+at ``src/Ankimon`` *without* executing the real ``src/Ankimon/__init__.py``.
+"""
+import sys
+import types
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SRC_DIR = REPO_ROOT / "src"
+
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+if "aqt" not in sys.modules:
+    aqt_stub = types.ModuleType("aqt")
+    aqt_utils_stub = types.ModuleType("aqt.utils")
+    aqt_utils_stub.showWarning = lambda *a, **k: None
+    aqt_utils_stub.showInfo = lambda *a, **k: None
+    aqt_utils_stub.tooltip = lambda *a, **k: None
+    aqt_stub.utils = aqt_utils_stub
+    aqt_stub.mw = types.SimpleNamespace()
+    aqt_stub.gui_hooks = types.SimpleNamespace()
+    sys.modules["aqt"] = aqt_stub
+    sys.modules["aqt.utils"] = aqt_utils_stub
+
+if "Ankimon" not in sys.modules:
+    ankimon_stub = types.ModuleType("Ankimon")
+    ankimon_stub.__path__ = [str(SRC_DIR / "Ankimon")]
+    sys.modules["Ankimon"] = ankimon_stub

--- a/tests/test_battle_engine.py
+++ b/tests/test_battle_engine.py
@@ -1,0 +1,83 @@
+import random
+
+from Ankimon.functions import battle_engine
+from Ankimon.business import bP_none_moves
+
+
+class TestResolveDamageMove:
+    def test_zero_base_power_uses_flat_damage(self):
+        move = {"basePower": 0, "target": "normal", "damage": 20, "type": "normal"}
+        dmg = battle_engine.resolve_damage_move(
+            move, level=10, multiplier=1, atk_stat=50, def_stat=50,
+            attacker_type=["Normal"], defender_type=["Normal"],
+        )
+        assert dmg == 20
+
+    def test_zero_base_power_non_normal_target_is_zero_not_crash(self):
+        # Regression test: bP_none_moves used to return None for any target
+        # other than "normal", which crashed `enemy_pokemon.hp -= dmg`.
+        move = {"basePower": 0, "target": "self", "type": "normal"}
+        dmg = battle_engine.resolve_damage_move(
+            move, level=10, multiplier=1, atk_stat=50, def_stat=50,
+            attacker_type=["Normal"], defender_type=["Normal"],
+        )
+        assert dmg == 0
+
+    def test_positive_base_power_deals_damage(self):
+        random.seed(0)
+        move = {"basePower": 40, "target": "normal", "type": "grass"}
+        dmg = battle_engine.resolve_damage_move(
+            move, level=10, multiplier=1, atk_stat=50, def_stat=50,
+            attacker_type=["Grass"], defender_type=["Water"], critRatio=1,
+        )
+        assert dmg > 0
+
+
+class TestApplySecondaryStatus:
+    def test_no_secondary_is_noop(self):
+        move = {"target": "normal"}
+        battle_status, slp_counter = battle_engine.apply_secondary_status(move, "fighting", 0)
+        assert battle_status == "fighting"
+        assert slp_counter == 0
+
+    def test_guaranteed_secondary_status_applies(self):
+        move = {"target": "normal", "secondary": {"status": "par", "chance": 100}}
+        battle_status, slp_counter = battle_engine.apply_secondary_status(move, "fighting", 0)
+        assert battle_status == "par"
+
+    def test_self_target_never_inflicts_status(self):
+        move = {"target": "self", "secondary": {"status": "par", "chance": 100}}
+        battle_status, slp_counter = battle_engine.apply_secondary_status(move, "fighting", 0)
+        assert battle_status == "fighting"
+
+    def test_sleep_status_sets_a_counter(self):
+        move = {"target": "normal", "secondary": {"status": "slp", "chance": 100}}
+        random.seed(0)
+        battle_status, slp_counter = battle_engine.apply_secondary_status(move, "fighting", 0)
+        assert battle_status == "slp"
+        assert 1 <= slp_counter <= 3
+
+
+class TestResolveStatusMove:
+    def test_self_boost_mutates_actor_stats_only(self):
+        actor_stats = {"atk": 50}
+        target_stats = {"atk": 50}
+        # "swordsdance" is a classic +2 Attack self-boost move present in the
+        # addon's real moves.json data file.
+        msg, battle_status, slp_counter = battle_engine.resolve_status_move(
+            "swordsdance", actor_stats, target_stats, "Machop", "Geodude", "", "fighting", 0,
+        )
+        assert actor_stats["atk"] > 50
+        assert target_stats["atk"] == 50
+        assert "Machop" in msg
+
+    def test_target_debuff_mutates_target_stats_only(self):
+        actor_stats = {"atk": 50, "def": 50}
+        target_stats = {"atk": 50, "def": 50}
+        # "growl" lowers the target's Attack.
+        msg, battle_status, slp_counter = battle_engine.resolve_status_move(
+            "growl", actor_stats, target_stats, "Machop", "Geodude", "", "fighting", 0,
+        )
+        assert target_stats["atk"] < 50
+        assert actor_stats["atk"] == 50
+        assert "Geodude" in msg

--- a/tests/test_battle_functions.py
+++ b/tests/test_battle_functions.py
@@ -1,0 +1,153 @@
+import random
+
+import pytest
+
+from Ankimon.functions.battle_functions import (
+    calc_atk_dmg,
+    calculate_hp,
+    get_effectiveness,
+    status_effect,
+)
+from Ankimon.pyobj.pokemon_obj import PokemonObject
+
+
+def make_pokemon(**overrides):
+    kwargs = dict(
+        name="Bulbasaur",
+        id=1,
+        level=10,
+        type=["Grass"],
+        stats={"hp": 45, "atk": 49, "def": 49, "spa": 65, "spd": 65, "spe": 45},
+        ev={"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0},
+        iv={"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0},
+        battle_status="fighting",
+    )
+    kwargs.update(overrides)
+    return PokemonObject(**kwargs)
+
+
+class TestGetEffectiveness:
+    def test_super_effective(self):
+        # Water vs Fire is super effective (2x)
+        assert get_effectiveness("water", ["Fire"]) == 2
+
+    def test_not_very_effective(self):
+        # Fire vs Water is not very effective (0.5x)
+        assert get_effectiveness("fire", ["Water"]) == 0.5
+
+    def test_neutral(self):
+        assert get_effectiveness("normal", ["Normal"]) == 1
+
+    def test_dual_type_multiplies(self):
+        # Electric vs Water/Flying: 2x * 2x = 4x
+        assert get_effectiveness("electric", ["Water", "Flying"]) == 4
+
+
+class TestCalcAtkDmg:
+    def test_returns_nonnegative_damage(self):
+        random.seed(0)
+        dmg = calc_atk_dmg(
+            level=10, critical=1, power=40, stat_atk=50, wild_stat_def=50,
+            main_type=["Grass"], move_type="grass", wild_type=["Water"], critRatio=1,
+        )
+        assert dmg > 0
+
+    def test_none_power_treated_same_as_zero_power(self):
+        random.seed(0)
+        none_dmg = calc_atk_dmg(
+            level=10, critical=1, power=None, stat_atk=50, wild_stat_def=50,
+            main_type=["Grass"], move_type="grass", wild_type=["Water"], critRatio=1,
+        )
+        random.seed(0)
+        zero_dmg = calc_atk_dmg(
+            level=10, critical=1, power=0, stat_atk=50, wild_stat_def=50,
+            main_type=["Grass"], move_type="grass", wild_type=["Water"], critRatio=1,
+        )
+        assert none_dmg == zero_dmg
+
+    def test_stab_increases_damage(self):
+        random.seed(1)
+        stab_dmg = calc_atk_dmg(10, 1, 40, 50, 50, ["Grass"], "grass", ["Normal"], 1)
+        random.seed(1)
+        no_stab_dmg = calc_atk_dmg(10, 1, 40, 50, 50, ["Fire"], "grass", ["Normal"], 1)
+        assert stab_dmg > no_stab_dmg
+
+    def test_crit_ratio_4_always_crits(self):
+        # critRatio > 3 forces a 100% crit chance path (still probabilistic on the
+        # "critical" multiplier itself being applied) - just assert it doesn't error
+        # and produces a positive result across repeated rolls.
+        for seed in range(5):
+            random.seed(seed)
+            dmg = calc_atk_dmg(10, 1, 40, 50, 50, ["Grass"], "grass", ["Water"], 4)
+            assert dmg >= 0
+
+
+class TestCalculateHp:
+    def test_higher_level_gives_more_hp(self):
+        low = calculate_hp(45, 5, {"hp": 0}, {"hp": 0})
+        high = calculate_hp(45, 50, {"hp": 0}, {"hp": 0})
+        assert high > low
+
+    def test_hp_is_int(self):
+        assert isinstance(calculate_hp(45, 10, {"hp": 0}, {"hp": 0}), int)
+
+
+class TestStatusEffect:
+    def test_returns_stats_not_undefined_name(self):
+        # Regression test for the confirmed bug: status_effect used to return
+        # the undefined name `battle_stats` instead of the local `stats`.
+        pokemon = make_pokemon(battle_status="fighting")
+        move = {"type": "normal", "target": "normal"}
+        msg, acc, stat, stats = status_effect(pokemon, move, slp_counter=2, msg="", acc=100)
+        assert stats == pokemon._battle_stats
+
+    def test_paralysis_reduces_speed_and_can_prevent_move(self):
+        pokemon = make_pokemon(battle_status="par")
+        move = {"type": "normal", "target": "normal"}
+        random.seed(0)
+        msg, acc, stat, stats = status_effect(pokemon, move, slp_counter=0, msg="", acc=100)
+        assert stats["spe"] == pytest.approx(pokemon.stats["spe"] * 0.5)
+        assert "speed is reduced" in msg
+
+    def test_sleep_counts_down_then_wakes(self):
+        pokemon = make_pokemon(battle_status="slp")
+        move = {"type": "normal", "target": "normal"}
+        msg, acc, stat, stats = status_effect(pokemon, move, slp_counter=2, msg="", acc=100)
+        assert stat == "slp"
+        assert "asleep" in msg
+
+        msg2, acc2, stat2, stats2 = status_effect(pokemon, move, slp_counter=1, msg="", acc=100)
+        assert stat2 is None
+        assert "no longer asleep" in msg2
+
+    def test_burn_deals_damage_over_time(self):
+        # Regression test: burn/poison/toxic used to compute damage into a
+        # local `hp` variable that was never written back to the Pokemon.
+        pokemon = make_pokemon(battle_status="brn")
+        starting_hp = pokemon.hp
+        move = {"type": "normal", "target": "normal"}
+        status_effect(pokemon, move, slp_counter=0, msg="", acc=100)
+        assert pokemon.hp < starting_hp
+
+    def test_poison_deals_damage_over_time(self):
+        pokemon = make_pokemon(battle_status="psn")
+        starting_hp = pokemon.hp
+        move = {"type": "normal", "target": "normal"}
+        status_effect(pokemon, move, slp_counter=0, msg="", acc=100)
+        assert pokemon.hp < starting_hp
+
+    def test_toxic_deals_damage_and_becomes_poison(self):
+        pokemon = make_pokemon(battle_status="tox")
+        starting_hp = pokemon.hp
+        move = {"type": "normal", "target": "normal"}
+        msg, acc, stat, stats = status_effect(pokemon, move, slp_counter=0, msg="", acc=100)
+        assert pokemon.hp < starting_hp
+        assert stat == "psn"
+
+    def test_freeze_thaws_on_fire_move(self):
+        pokemon = make_pokemon(battle_status="frz")
+        move = {"type": "fire", "target": "normal"}
+        random.seed(0)
+        msg, acc, stat, stats = status_effect(pokemon, move, slp_counter=0, msg="", acc=100)
+        assert stat is None
+        assert "no longer frozen" in msg


### PR DESCRIPTION
## Summary

**Battle hardening** (found while extracting the battle round into a testable module):
- `status_effect()` returned an undefined name, crashing every caller
- burn/poison/toxic damage-over-time was computed but never written back - a complete no-op
- freeze thaw chance was inverted (fire moves kept you frozen instead of thawing you)
- STAB bonus never applied (`move_type == main_type` compared a string to a list)
- `PokemonObject._battle_stats` always ended up equal to `ev`, not the real stats, due to an overwrite-in-a-loop bug
- a move-target crash (`bP_none_moves` returning `None` for non-"normal" targets)
- status/sleep-counter state was silently discarded between review rounds instead of persisting
- two bare `except:` blocks that swallowed all errors are now narrowed + logged
- new `functions/battle_engine.py` (pure, Anki-independent) + `tests/` (pytest, 26 tests) covering all of the above
- CI workflow to run the tests on push/PR

**Raid feature**: multiplayer shared boss fights, synced through a new self-hostable Go server.
- `raid-server/`: in-memory Go relay (create/list/get/join/attack), anti-cheat damage clamping server-side, `go test` incl. a 50-goroutine concurrency check
- A follow-up commit closes 3 issues a security review caught in the first pass: identity spoofing via a body `username` field, damage-ceiling gaming via unbounded client-submitted stats, and an unguarded float->int conversion
- Addon client: `functions/raid_functions.py`, `pyobj/raid_obj.py`, `pyobj/raid_dialog.py`, a "Raid Battle" menu entry, and reviewer-hook wiring that reports each hit to an active raid (additive to solo battles, not a replacement)

## Test plan

- [x] `pytest tests/` - 26 passed
- [x] `go build ./... && go vet ./... && go test ./...` in `raid-server/` - all pass
- [x] Manual `curl` smoke test of the full create → join → attack → clamp → state flow (see `raid-server/README.md`)
- [ ] Addon-side UI wiring is verified by code review + the pure-function tests only - not clicked through in a live Anki instance (documented in the plan, no headless Anki available here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XVxa1B1U725TUq364uN251