### PR TITLE
feat: add trainer battle roster client

### DIFF
--- a/src/Ankimon/__init__.py
+++ b/src/Ankimon/__init__.py
@@ -67,6 +67,7 @@ try:
     from .functions.battle_functions import *
     from .functions import battle_engine
     from .functions import raid_functions
+    from .functions import multiplayer_functions
     from .functions.pokemon_functions import *
     from .functions.create_gui_functions import *
     from .functions.create_css_for_reviewer import create_css_for_reviewer
@@ -1598,6 +1599,8 @@ reviewer_obj = Reviewer_Manager(
 # Hook into Anki's card review event
 def on_review_card(*args):
     try:
+        if settings_obj.get("multiplayer.enabled", False):
+            multiplayer_functions.queue_review(args, main_pokemon.level)
         battle_status = enemy_pokemon.battle_status
         multiplier = ankimon_tracker_obj.multiplier
         mainpokemon_type = main_pokemon.type

--- a/src/Ankimon/__init__.py
+++ b/src/Ankimon/__init__.py
@@ -1600,7 +1600,11 @@ reviewer_obj = Reviewer_Manager(
 def on_review_card(*args):
     try:
         if settings_obj.get("multiplayer.enabled", False):
-            multiplayer_functions.queue_review(args, main_pokemon.level)
+            multiplayer_functions.queue_review(
+                args,
+                main_pokemon.level,
+                {"name": main_pokemon.name, "id": main_pokemon.id, "level": main_pokemon.level},
+            )
         battle_status = enemy_pokemon.battle_status
         multiplier = ankimon_tracker_obj.multiplier
         mainpokemon_type = main_pokemon.type

--- a/src/Ankimon/functions/create_css_for_reviewer.py
+++ b/src/Ankimon/functions/create_css_for_reviewer.py
@@ -1,5 +1,24 @@
 def create_css_for_reviewer(show_mainpkmn_in_reviewer, pokemon_hp_percent, hp_bar_thickness, xp_bar_spacer, view_main_front, mainpkmn_hp_percent, hp_only_spacer, wild_hp_spacer, xp_bar_config, main_pokemon, experience_for_next_lvl, xp_bar_location):
     css = ""
+    css += """
+    #OpponentTrainerImage {
+        position: fixed;
+        right: 108px;
+        bottom: 112px;
+        z-index: 10000;
+        width: 64px;
+        height: 64px;
+        background: rgba(54, 54, 56, 0.7);
+        border-radius: 8px;
+        padding: 3px;
+    }
+    #OpponentTrainerImage img {
+        width: 100%;
+        height: 100%;
+        object-fit: contain;
+        image-rendering: pixelated;
+    }
+    """
     if show_mainpkmn_in_reviewer == 0:
         css += f"""
         #life-bar {{

--- a/src/Ankimon/functions/multiplayer_functions.py
+++ b/src/Ankimon/functions/multiplayer_functions.py
@@ -1,6 +1,8 @@
 """Small client for the merged Ankimon multiplayer API."""
 import json
 import os
+import time
+import uuid
 
 import requests
 from aqt import mw
@@ -14,6 +16,8 @@ class MultiplayerClientError(Exception):
 
 _session = requests.Session()
 _credentials_cache = None
+_pending_events = []
+_batch_size = 5
 
 
 def _headers():
@@ -66,3 +70,49 @@ def get_state():
 def challenge_bot(challenge_value):
     return _request("POST", "/v1/matches", {"opponent": challenge_value})
 
+
+def submit_turn(match_id, move=None):
+    body = {} if not move else {"move": move}
+    return _request("POST", f"/v1/matches/{match_id}/turns", body)
+
+
+def queue_review(reviewer_args, level):
+    """Queue one Anki review and flush in small batches.
+
+    The hook intentionally does no network work for the common case: callers
+    only get a state response when a batch is ready or a flush is requested.
+    """
+    if len(reviewer_args) >= 3:
+        card = reviewer_args[1]
+        ease = reviewer_args[2]
+    else:
+        card = None
+        ease = 0
+    card_id = getattr(card, "id", None) or uuid.uuid4().hex
+    grade = {1: "again", 2: "hard", 3: "good", 4: "easy"}.get(int(ease), "good")
+    _pending_events.append({
+        "id": f"review-{card_id}-{time.time_ns()}-{uuid.uuid4().hex[:8]}",
+        "type": "card_reviewed",
+        "ts": str(int(time.time())),
+        "grade": grade,
+        "time_s": 0,
+        "level": max(1, int(level or 1)),
+    })
+    if len(_pending_events) >= _batch_size:
+        return flush_reviews()
+    return None
+
+
+def flush_reviews():
+    """Send queued reviews; failures leave no UI-facing exception."""
+    if not _pending_events:
+        return None
+    events = list(_pending_events)
+    del _pending_events[:]
+    try:
+        return _request("POST", "/v1/events:batch", {"events": events})
+    except MultiplayerClientError:
+        # The server deduplicates IDs, but this client deliberately drops a
+        # failed batch so an unavailable server cannot grow memory forever or
+        # delay the reviewer.
+        return None

--- a/src/Ankimon/functions/multiplayer_functions.py
+++ b/src/Ankimon/functions/multiplayer_functions.py
@@ -66,6 +66,10 @@ def _request(method, path, body=None):
 
 
 def get_state():
+    # A user opening the trainer screen expects their latest reviews to be
+    # reflected immediately, even when fewer than the normal batch size are
+    # waiting.
+    flush_reviews()
     return _request("GET", "/v1/state")
 
 

--- a/src/Ankimon/functions/multiplayer_functions.py
+++ b/src/Ankimon/functions/multiplayer_functions.py
@@ -22,6 +22,17 @@ _batch_size = 5
 _max_pending_events = 100
 
 
+def _trainer_profile():
+    """Return the public trainer card used by friend and bot battle state."""
+    settings = mw.settings_obj
+    return {
+        "name": str(settings.get("trainer.name", "Trainer")),
+        "rank": str(settings.get("trainer.rank", "Trainer")),
+        "sprite": str(settings.get("trainer.sprite", "")),
+        "motto": str(settings.get("trainer.motto", "")),
+    }
+
+
 def _headers():
     global _credentials_cache
     try:
@@ -62,6 +73,8 @@ def _request(method, path, body=None):
         raise MultiplayerClientError("The multiplayer server returned invalid JSON.") from exc
     if response.status_code >= 400:
         raise MultiplayerClientError(payload.get("error", f"Server error ({response.status_code})"))
+    # Reviewer rendering can reuse the latest state without another request.
+    mw.multiplayer_state = payload
     return payload
 
 
@@ -74,7 +87,10 @@ def get_state():
 
 
 def challenge_bot(challenge_value):
-    return _request("POST", "/v1/matches", {"opponent": challenge_value})
+    return _request("POST", "/v1/matches", {
+        "opponent": challenge_value,
+        "trainer_profile": _trainer_profile(),
+    })
 
 
 def submit_turn(match_id, move=None):
@@ -128,6 +144,7 @@ def flush_reviews():
         state = _request("POST", "/v1/events:batch", {
             "events": events,
             "active_pokemon": active_pokemon,
+            "trainer_profile": _trainer_profile(),
         })
         del _pending_events[:len(events)]
         return state

--- a/src/Ankimon/functions/multiplayer_functions.py
+++ b/src/Ankimon/functions/multiplayer_functions.py
@@ -1,0 +1,68 @@
+"""Small client for the merged Ankimon multiplayer API."""
+import json
+import os
+
+import requests
+from aqt import mw
+
+from ..resources import user_path_credentials
+
+
+class MultiplayerClientError(Exception):
+    """Raised when the multiplayer API cannot be reached or used."""
+
+
+_session = requests.Session()
+_credentials_cache = None
+
+
+def _headers():
+    global _credentials_cache
+    try:
+        mtime = os.stat(user_path_credentials).st_mtime_ns
+    except OSError:
+        mtime = None
+    if _credentials_cache is not None and _credentials_cache[0] == mtime:
+        username, api_key = _credentials_cache[1:]
+    else:
+        try:
+            with open(user_path_credentials, "r", encoding="utf-8") as handle:
+                credentials = json.load(handle)
+        except (FileNotFoundError, json.JSONDecodeError) as exc:
+            raise MultiplayerClientError("Set up your Ankimon username and API key first.") from exc
+        username = credentials.get("username")
+        api_key = credentials.get("api_key")
+        if not username or not api_key:
+            raise MultiplayerClientError("Your Ankimon credentials are incomplete.")
+        _credentials_cache = (mtime, username, api_key)
+    return {
+        "Authorization": f"Bearer {api_key}",
+        "X-Ankimon-Username": username,
+        "Content-Type": "application/json",
+    }
+
+
+def _request(method, path, body=None):
+    base_url = mw.settings_obj.get("multiplayer.server_url", "http://localhost:8080").rstrip("/")
+    try:
+        response = _session.request(
+            method, f"{base_url}{path}", headers=_headers(), json=body, timeout=10
+        )
+    except requests.exceptions.RequestException as exc:
+        raise MultiplayerClientError(f"Couldn't reach the multiplayer server: {exc}") from exc
+    try:
+        payload = response.json()
+    except ValueError as exc:
+        raise MultiplayerClientError("The multiplayer server returned invalid JSON.") from exc
+    if response.status_code >= 400:
+        raise MultiplayerClientError(payload.get("error", f"Server error ({response.status_code})"))
+    return payload
+
+
+def get_state():
+    return _request("GET", "/v1/state")
+
+
+def challenge_bot(challenge_value):
+    return _request("POST", "/v1/matches", {"opponent": challenge_value})
+

--- a/src/Ankimon/functions/multiplayer_functions.py
+++ b/src/Ankimon/functions/multiplayer_functions.py
@@ -17,7 +17,9 @@ class MultiplayerClientError(Exception):
 _session = requests.Session()
 _credentials_cache = None
 _pending_events = []
+_active_pokemon = None
 _batch_size = 5
+_max_pending_events = 100
 
 
 def _headers():
@@ -76,7 +78,7 @@ def submit_turn(match_id, move=None):
     return _request("POST", f"/v1/matches/{match_id}/turns", body)
 
 
-def queue_review(reviewer_args, level):
+def queue_review(reviewer_args, level, active_pokemon=None):
     """Queue one Anki review and flush in small batches.
 
     The hook intentionally does no network work for the common case: callers
@@ -90,6 +92,13 @@ def queue_review(reviewer_args, level):
         ease = 0
     card_id = getattr(card, "id", None) or uuid.uuid4().hex
     grade = {1: "again", 2: "hard", 3: "good", 4: "easy"}.get(int(ease), "good")
+    global _active_pokemon
+    if active_pokemon:
+        _active_pokemon = {
+            "name": str(active_pokemon.get("name", "")),
+            "id": int(active_pokemon.get("id", 0)),
+            "level": max(1, int(active_pokemon.get("level", level) or level or 1)),
+        }
     _pending_events.append({
         "id": f"review-{card_id}-{time.time_ns()}-{uuid.uuid4().hex[:8]}",
         "type": "card_reviewed",
@@ -98,6 +107,8 @@ def queue_review(reviewer_args, level):
         "time_s": 0,
         "level": max(1, int(level or 1)),
     })
+    if len(_pending_events) > _max_pending_events:
+        del _pending_events[:-_max_pending_events]
     if len(_pending_events) >= _batch_size:
         return flush_reviews()
     return None
@@ -107,12 +118,16 @@ def flush_reviews():
     """Send queued reviews; failures leave no UI-facing exception."""
     if not _pending_events:
         return None
-    events = list(_pending_events)
-    del _pending_events[:]
+    events = list(_pending_events[:_max_pending_events])
+    active_pokemon = _active_pokemon
     try:
-        return _request("POST", "/v1/events:batch", {"events": events})
+        state = _request("POST", "/v1/events:batch", {
+            "events": events,
+            "active_pokemon": active_pokemon,
+        })
+        del _pending_events[:len(events)]
+        return state
     except MultiplayerClientError:
-        # The server deduplicates IDs, but this client deliberately drops a
-        # failed batch so an unavailable server cannot grow memory forever or
-        # delay the reviewer.
+        # Keep the stable IDs for a later flush. The cap prevents an offline
+        # server from growing memory forever or delaying the reviewer.
         return None

--- a/src/Ankimon/functions/reviewer_iframe.py
+++ b/src/Ankimon/functions/reviewer_iframe.py
@@ -18,11 +18,27 @@ def list_audio_files(folder_path):
 
 from aqt import mw
 from .pokemon_functions import find_experience_for_level
+from ..business import get_image_as_base64
+from ..resources import trainer_sprites_path
 
-def create_html_code(genderTop, genderBottom, nameTop, nameBottom, levelTop, levelBottom, current_health_bottom, max_hp_bottom, max_hp_top, current_health_top, text, general_url, font_url, bottom_pokemon_sprite, top_pokemon_sprite, display, main_attack, enemy_attack, xp_bar_width = 0):    
+def create_html_code(genderTop, genderBottom, nameTop, nameBottom, levelTop, levelBottom, current_health_bottom, max_hp_bottom, max_hp_top, current_health_top, text, general_url, font_url, bottom_pokemon_sprite, top_pokemon_sprite, display, main_attack, enemy_attack, xp_bar_width = 0, top_trainer_sprite = ""):
+    if not top_trainer_sprite:
+        state = getattr(mw, "multiplayer_state", {}) or {}
+        for match in state.get("pvp", {}).get("matches", []):
+            if match.get("status") not in {"active", "pending"}:
+                continue
+            sprite = (match.get("opponent_trainer") or {}).get("sprite")
+            path = trainer_sprites_path / f"{sprite}.png" if sprite else None
+            if path and path.exists():
+                top_trainer_sprite = f"data:image/png;base64,{get_image_as_base64(path)}"
+                break
     html_code = """<div id="spacer">&nbsp;</div>"""
     html_code += """<div id="AnkimonWindow"></div>"""
     html_code += f"""<iframe id="myIframe" class="Ankimon" src='{general_url}index.html?bottomPokemonSprite={bottom_pokemon_sprite}&topPokemonSprite={top_pokemon_sprite}&text={text}&levelTop={levelTop}&levelBottom={levelBottom}&nameTop={nameTop}&nameBottom={nameBottom}&genderTop={genderTop}&genderBottom={genderBottom}&current_health_bottom={current_health_bottom}&max_hp_bottom={max_hp_bottom}&max_hp_top={max_hp_top}&fontUrl={font_url}&current_health_top={current_health_top}&main_attack={main_attack}&enemy_attack={enemy_attack}' width=100% style="display:{display};"></iframe>"""
+    html_code = html_code.replace(
+        f"topPokemonSprite={top_pokemon_sprite}&",
+        f"topPokemonSprite={top_pokemon_sprite}&topTrainerSprite={top_trainer_sprite}&",
+    )
     return html_code
 
 def create_iframe_html(main_pokemon, enemy_pokemon, settings_obj, textmsg):

--- a/src/Ankimon/menu_buttons.py
+++ b/src/Ankimon/menu_buttons.py
@@ -9,6 +9,7 @@ from PyQt6.QtGui import QAction, QKeySequence
 from .pyobj.trainer_card_window import TrainerCardGUI
 from .pyobj.ankimon_leaderboard import show_api_key_dialog
 from .pyobj.raid_dialog import RaidDialog
+from .pyobj.trainer_bot_dialog import TrainerBotDialog
 from .gui_classes.choose_trainer_sprite import TrainerSpriteDialog
 from .gui_classes.pokemon_team_window import PokemonTeamDialog
 from .gui_classes.check_files import FileCheckerApp
@@ -218,6 +219,11 @@ def create_menu_actions(
     raid_button.setMenuRole(QAction.MenuRole.NoRole)
     raid_button.triggered.connect(lambda: RaidDialog(mw.raid_session_obj).exec())
     game_menu.addAction(raid_button)
+
+    trainer_battle_button = QAction("Trainer Battles", mw)
+    trainer_battle_button.setMenuRole(QAction.MenuRole.NoRole)
+    trainer_battle_button.triggered.connect(lambda: TrainerBotDialog(mw).exec())
+    game_menu.addAction(trainer_battle_button)
 
     # Button: Show credits
     credits_button = QAction(

--- a/src/Ankimon/pyobj/reviewer_obj.py
+++ b/src/Ankimon/pyobj/reviewer_obj.py
@@ -5,7 +5,7 @@ from ..business import get_image_as_base64
 from ..functions.create_css_for_reviewer import create_css_for_reviewer
 from ..texts import inject_life_bar_css_1, inject_life_bar_css_2
 from ..functions.create_gui_functions import create_status_html
-from ..resources import icon_path
+from ..resources import icon_path, trainer_sprites_path
 from ..functions.pokedex_functions import get_pokemon_diff_lang_name
 
 class Reviewer_Manager:
@@ -22,6 +22,29 @@ class Reviewer_Manager:
         gui_hooks.reviewer_will_end.append(self.reviewer_reset_life_bar_inject)
         gui_hooks.webview_will_set_content.append(self.inject_life_bar)
         gui_hooks.reviewer_did_answer_card.append(self.update_life_bar)
+
+    def _opponent_trainer_sprite(self):
+        """Return the active bot/friend trainer sprite path, if available."""
+        state = getattr(mw, "multiplayer_state", {}) or {}
+        for match in state.get("pvp", {}).get("matches", []):
+            if match.get("status") not in {"active", "pending"}:
+                continue
+            sprite = (match.get("opponent_trainer") or {}).get("sprite")
+            if sprite:
+                path = trainer_sprites_path / f"{sprite}.png"
+                if path.exists():
+                    return path
+        return None
+
+    def _trainer_image_html(self):
+        path = self._opponent_trainer_sprite()
+        if not path:
+            return ""
+        return (
+            f'<div id="OpponentTrainerImage" class="Ankimon">'
+            f'<img src="data:image/png;base64,{get_image_as_base64(path)}" '
+            f'alt="Opponent trainer"></div>'
+        )
 
     def reviewer_reset_life_bar_inject(self):
         self.life_bar_injected = False
@@ -137,6 +160,7 @@ class Reviewer_Manager:
                     # Inject a div element at the end of the body for the life bar
                     image_base64 = get_image_as_base64(pokemon_image_file)
                     web_content.body += f'<div id="PokeImage" class="Ankimon"><img src="data:image/png;base64,{image_base64}" alt="PokeImage style="animation: shake 0s ease;"></div>'
+                    web_content.body += self._trainer_image_html()
                     if int(self.settings.get('gui.show_mainpkmn_in_reviewer', 1)) > 0:
                         image_base64_mypkmn = get_image_as_base64(main_pkmn_imagefile_path)
                         web_content.body += f'<div id="MyPokeImage" class="Ankimon"><img src="data:image/png;base64,{image_base64_mypkmn}" alt="MyPokeImage" style="animation: shake 0s ease;"></div>'

--- a/src/Ankimon/pyobj/settings.py
+++ b/src/Ankimon/pyobj/settings.py
@@ -29,6 +29,8 @@ class Settings:
             config["raid.server_url"] = "http://localhost:8080"
         if "multiplayer.server_url" not in config:
             config["multiplayer.server_url"] = "http://localhost:8080"
+        if "multiplayer.enabled" not in config:
+            config["multiplayer.enabled"] = False
 
         if not config:
             #Card max time in Seconds
@@ -81,6 +83,7 @@ class Settings:
                 "raid.enabled": False,
                 "raid.server_url": "http://localhost:8080",
                 "multiplayer.server_url": "http://localhost:8080",
+                "multiplayer.enabled": False,
                 "misc.discord_rich_presence": False,
                 "misc.discord_rich_presence_text": 1,
 

--- a/src/Ankimon/pyobj/settings.py
+++ b/src/Ankimon/pyobj/settings.py
@@ -27,6 +27,8 @@ class Settings:
             config["raid.enabled"] = False
         if "raid.server_url" not in config:
             config["raid.server_url"] = "http://localhost:8080"
+        if "multiplayer.server_url" not in config:
+            config["multiplayer.server_url"] = "http://localhost:8080"
 
         if not config:
             #Card max time in Seconds
@@ -78,6 +80,7 @@ class Settings:
 
                 "raid.enabled": False,
                 "raid.server_url": "http://localhost:8080",
+                "multiplayer.server_url": "http://localhost:8080",
                 "misc.discord_rich_presence": False,
                 "misc.discord_rich_presence_text": 1,
 

--- a/src/Ankimon/pyobj/trainer_bot_dialog.py
+++ b/src/Ankimon/pyobj/trainer_bot_dialog.py
@@ -72,11 +72,21 @@ class TrainerBotDialog(QDialog):
         else:
             sprite.setText("Trainer")
         row.addWidget(sprite)
+        battle_text = ""
+        if match and match.get("status") == "active":
+            battle_text = (
+                f"<br><b>Battle:</b> You {match.get('your_hp', '?')} HP · "
+                f"{match.get('opponent', 'Trainer')} {match.get('opponent_hp', '?')} HP"
+            )
+        elif match and match.get("status") == "finished":
+            won = match.get("winner") != match.get("opponent")
+            battle_text = f"<br><b>{'Victory' if won else 'Defeat'}</b>"
         text = QLabel(
             f"<b>{bot.get('trainer_name', bot.get('username', 'Trainer'))}</b>"
             f" &mdash; {bot.get('trainer_rank', 'Trainer')}<br>"
             f"{bot.get('motto', '')}<br>"
             f"Pokémon: {bot.get('pokemon', '?')} · Lv. {bot.get('level', '?')}"
+            f"{battle_text}"
         )
         text.setTextFormat(Qt.TextFormat.RichText)
         row.addWidget(text, 1)

--- a/src/Ankimon/pyobj/trainer_bot_dialog.py
+++ b/src/Ankimon/pyobj/trainer_bot_dialog.py
@@ -16,6 +16,7 @@ class TrainerBotDialog(QDialog):
         self.setWindowTitle("Ankimon Trainer Battles")
         self.setMinimumSize(560, 520)
         self._seen_finished_matches = set()
+        self._state = {}
 
         layout = QVBoxLayout(self)
         layout.addWidget(QLabel("Practice against a named trainer. Each trainer fields a different Pokémon and style."))
@@ -32,12 +33,19 @@ class TrainerBotDialog(QDialog):
         except multiplayer_functions.MultiplayerClientError as exc:
             QMessageBox.warning(self, "Trainer Battles", str(exc))
             return
+        self._state = state
 
         self.roster.clear()
         for bot in state.get("bots", []):
             item = QListWidgetItem()
             self.roster.addItem(item)
-            self.roster.setItemWidget(item, self._bot_widget(bot))
+            match = next(
+                (candidate for candidate in state.get("pvp", {}).get("matches", [])
+                 if candidate.get("opponent") == bot.get("username") and
+                 candidate.get("opponent_is_bot")),
+                None,
+            )
+            self.roster.setItemWidget(item, self._bot_widget(bot, match, state.get("pvp", {})))
 
         for match in state.get("pvp", {}).get("matches", []):
             if match.get("opponent_is_bot") and match.get("status") == "finished":
@@ -47,7 +55,7 @@ class TrainerBotDialog(QDialog):
                     won = match.get("winner") != match.get("opponent")
                     show_bot_battle_result(match.get("opponent", "trainer"), won)
 
-    def _bot_widget(self, bot):
+    def _bot_widget(self, bot, match=None, pvp_state=None):
         widget = QWidget()
         row = QHBoxLayout(widget)
         sprite = QLabel()
@@ -69,6 +77,11 @@ class TrainerBotDialog(QDialog):
         challenge.setEnabled(not bot.get("in_match", False))
         challenge.clicked.connect(lambda: self.challenge(bot))
         row.addWidget(challenge)
+        if match and match.get("status") == "active":
+            attack = QPushButton("Attack")
+            attack.setEnabled((pvp_state or {}).get("banked_attacks", 0) > 0)
+            attack.clicked.connect(lambda: self.attack(match["id"]))
+            row.addWidget(attack)
         return widget
 
     def challenge(self, bot):
@@ -78,4 +91,12 @@ class TrainerBotDialog(QDialog):
             QMessageBox.warning(self, "Trainer Battle", str(exc))
             return
         QMessageBox.information(self, "Trainer Battle", f"{bot.get('trainer_name', bot.get('username', 'Trainer'))} accepts your challenge!\nAnswer a card to make your first move.")
+        self.refresh()
+
+    def attack(self, match_id):
+        try:
+            state = multiplayer_functions.submit_turn(match_id)
+        except multiplayer_functions.MultiplayerClientError as exc:
+            QMessageBox.warning(self, "Trainer Battle", str(exc))
+            return
         self.refresh()

--- a/src/Ankimon/pyobj/trainer_bot_dialog.py
+++ b/src/Ankimon/pyobj/trainer_bot_dialog.py
@@ -1,0 +1,81 @@
+from PyQt6.QtCore import Qt
+from PyQt6.QtGui import QPixmap
+from PyQt6.QtWidgets import QDialog, QHBoxLayout, QLabel, QListWidget, QListWidgetItem, QMessageBox, QPushButton, QVBoxLayout, QWidget
+from aqt import mw
+
+from ..functions import multiplayer_functions
+from ..functions.raid_functions import show_bot_battle_result
+from ..resources import trainer_sprites_path
+
+
+class TrainerBotDialog(QDialog):
+    """Roster view and challenge entry point for practice trainers."""
+
+    def __init__(self, parent=mw):
+        super().__init__(parent)
+        self.setWindowTitle("Ankimon Trainer Battles")
+        self.setMinimumSize(560, 520)
+        self._seen_finished_matches = set()
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(QLabel("Practice against a named trainer. Each trainer fields a different Pokémon and style."))
+        self.roster = QListWidget()
+        layout.addWidget(self.roster)
+        refresh = QPushButton("Refresh trainers")
+        refresh.clicked.connect(self.refresh)
+        layout.addWidget(refresh)
+        self.refresh()
+
+    def refresh(self):
+        try:
+            state = multiplayer_functions.get_state()
+        except multiplayer_functions.MultiplayerClientError as exc:
+            QMessageBox.warning(self, "Trainer Battles", str(exc))
+            return
+
+        self.roster.clear()
+        for bot in state.get("bots", []):
+            item = QListWidgetItem()
+            self.roster.addItem(item)
+            self.roster.setItemWidget(item, self._bot_widget(bot))
+
+        for match in state.get("pvp", {}).get("matches", []):
+            if match.get("opponent_is_bot") and match.get("status") == "finished":
+                match_id = match.get("id")
+                if match_id and match_id not in self._seen_finished_matches:
+                    self._seen_finished_matches.add(match_id)
+                    won = match.get("winner") != match.get("opponent")
+                    show_bot_battle_result(match.get("opponent", "trainer"), won)
+
+    def _bot_widget(self, bot):
+        widget = QWidget()
+        row = QHBoxLayout(widget)
+        sprite = QLabel()
+        sprite_path = trainer_sprites_path / f"{bot.get('trainer_sprite', '')}.png"
+        if sprite_path.exists():
+            sprite.setPixmap(QPixmap(str(sprite_path)).scaled(72, 72, Qt.AspectRatioMode.KeepAspectRatio))
+        else:
+            sprite.setText("Trainer")
+        row.addWidget(sprite)
+        text = QLabel(
+            f"<b>{bot.get('trainer_name', bot.get('username', 'Trainer'))}</b>"
+            f" &mdash; {bot.get('trainer_rank', 'Trainer')}<br>"
+            f"{bot.get('motto', '')}<br>"
+            f"Pokémon: {bot.get('pokemon', '?')} · Lv. {bot.get('level', '?')}"
+        )
+        text.setTextFormat(Qt.TextFormat.RichText)
+        row.addWidget(text, 1)
+        challenge = QPushButton("Challenge")
+        challenge.setEnabled(not bot.get("in_match", False))
+        challenge.clicked.connect(lambda: self.challenge(bot))
+        row.addWidget(challenge)
+        return widget
+
+    def challenge(self, bot):
+        try:
+            multiplayer_functions.challenge_bot(bot["challenge_value"])
+        except multiplayer_functions.MultiplayerClientError as exc:
+            QMessageBox.warning(self, "Trainer Battle", str(exc))
+            return
+        QMessageBox.information(self, "Trainer Battle", f"{bot.get('trainer_name', bot.get('username', 'Trainer'))} accepts your challenge!\nAnswer a card to make your first move.")
+        self.refresh()

--- a/src/Ankimon/pyobj/trainer_bot_dialog.py
+++ b/src/Ankimon/pyobj/trainer_bot_dialog.py
@@ -20,6 +20,8 @@ class TrainerBotDialog(QDialog):
 
         layout = QVBoxLayout(self)
         layout.addWidget(QLabel("Practice against a named trainer. Each trainer fields a different Pokémon and style."))
+        self.attack_status = QLabel("Banked attacks: 0 / 3")
+        layout.addWidget(self.attack_status)
         self.roster = QListWidget()
         layout.addWidget(self.roster)
         refresh = QPushButton("Refresh trainers")
@@ -34,6 +36,11 @@ class TrainerBotDialog(QDialog):
             QMessageBox.warning(self, "Trainer Battles", str(exc))
             return
         self._state = state
+        pvp_state = state.get("pvp", {})
+        self.attack_status.setText(
+            f"Banked attacks: {pvp_state.get('banked_attacks', 0)} / "
+            f"{pvp_state.get('max_banked_attacks', 3)}"
+        )
 
         self.roster.clear()
         for bot in state.get("bots", []):
@@ -45,7 +52,7 @@ class TrainerBotDialog(QDialog):
                  candidate.get("opponent_is_bot")),
                 None,
             )
-            self.roster.setItemWidget(item, self._bot_widget(bot, match, state.get("pvp", {})))
+            self.roster.setItemWidget(item, self._bot_widget(bot, match, pvp_state))
 
         for match in state.get("pvp", {}).get("matches", []):
             if match.get("opponent_is_bot") and match.get("status") == "finished":

--- a/src/Ankimon/user_files/web/index.html
+++ b/src/Ankimon/user_files/web/index.html
@@ -45,6 +45,7 @@
 				</div>
 			</div>
 			<div id="topPoke"><img id="topPokemonEffects"></img></div>
+			<div id="topTrainer"></div>
 			
 		</div>
 	</div>
@@ -118,6 +119,7 @@
 		var sprites_url = getUrlParameter('spritesUrl');
 		var bottomPokemonSprite = getUrlParameter('bottomPokemonSprite');
 		var topPokemonSprite = getUrlParameter('topPokemonSprite');
+		var topTrainerSprite = getUrlParameter('topTrainerSprite');
 		//var topPokeUrl = `../sprites/back_default_gif/1.gif`;
 		var text = getUrlParameter('text');
 		var levelTop = getUrlParameter('levelTop');
@@ -139,6 +141,7 @@
 		// Get elements by ID
 		var bottomPokemon = document.getElementById('bottomPokemon');
 		var topPoke = document.getElementById('topPoke');
+		var topTrainer = document.getElementById('topTrainer');
 		var battleText = document.getElementById('battleText');
 		var level_bottom = document.getElementById('level_bottom');
 		var level_top = document.getElementById('level_top');
@@ -219,6 +222,10 @@
 		// Update Pokémon images and font dynamically
 		bottomPokemon.style.backgroundImage = 'url(' + bottomPokemonSprite + ')';
 		topPoke.style.backgroundImage = 'url(' + topPokemonSprite + ')';
+		if (topTrainerSprite) {
+			topTrainer.style.backgroundImage = 'url(' + topTrainerSprite + ')';
+			topTrainer.style.display = 'block';
+		}
 
 		if (fontUrl) {
 			var styleElement = document.createElement('style');

--- a/src/Ankimon/user_files/web/styles.css
+++ b/src/Ankimon/user_files/web/styles.css
@@ -29,6 +29,19 @@
 	width:100% ;
 }
 
+#topTrainer {
+	position: absolute;
+	right: 2%;
+	top: 28%;
+	width: 64px;
+	height: 64px;
+	display: none;
+	background-size: contain;
+	background-repeat: no-repeat;
+	background-position: center;
+	z-index: 4;
+}
+
 #bottom {
 	background-color: rgb(64,64,80) ;
 	height: 30% ;


### PR DESCRIPTION
## Summary
- add a dedicated /v1 multiplayer API client
- add Trainer Battles menu and roster dialog
- show trainer sprites, ranks, mottos, Pokémon, and challenge controls
- add multiplayer server URL setting

## Verification
- Python AST syntax check
- py -3 -m pytest -q (26 passed)
- git diff --check