### PR TITLE
feat: add friends to trainer battles

### DIFF
--- a/src/Ankimon/functions/raid_functions.py
+++ b/src/Ankimon/functions/raid_functions.py
@@ -165,7 +165,7 @@ def announce_completion(session):
 
 
 def show_bot_battle_result(opponent_name, won, pokemon_name=None):
-    """Shared popup hook for the multiplayer bot battle client."""
+    """Show a shared result popup for any multiplayer trainer battle."""
     result = "Victory" if won else "Defeat"
     detail = f"\n{pokemon_name}" if pokemon_name else ""
     showInfo(f"{result} against {opponent_name}!{detail}")

--- a/src/Ankimon/pyobj/trainer_bot_dialog.py
+++ b/src/Ankimon/pyobj/trainer_bot_dialog.py
@@ -71,7 +71,7 @@ class TrainerBotDialog(QDialog):
             )
 
         for match in state.get("pvp", {}).get("matches", []):
-            if match.get("opponent_is_bot") and match.get("status") == "finished":
+            if match.get("status") == "finished":
                 match_id = match.get("id")
                 if match_id and match_id not in self._seen_finished_matches:
                     self._seen_finished_matches.add(match_id)

--- a/src/Ankimon/pyobj/trainer_bot_dialog.py
+++ b/src/Ankimon/pyobj/trainer_bot_dialog.py
@@ -54,6 +54,22 @@ class TrainerBotDialog(QDialog):
             )
             self.roster.setItemWidget(item, self._bot_widget(bot, match, pvp_state))
 
+        human_enabled = pvp_state.get("human_enabled", False)
+        for friend in state.get("friends", []):
+            if friend.get("bot"):
+                continue
+            item = QListWidgetItem()
+            self.roster.addItem(item)
+            match = next(
+                (candidate for candidate in state.get("pvp", {}).get("matches", [])
+                 if candidate.get("opponent") == friend.get("username") and
+                 not candidate.get("opponent_is_bot")),
+                None,
+            )
+            self.roster.setItemWidget(
+                item, self._bot_widget(friend, match, pvp_state, human_enabled)
+            )
+
         for match in state.get("pvp", {}).get("matches", []):
             if match.get("opponent_is_bot") and match.get("status") == "finished":
                 match_id = match.get("id")
@@ -62,11 +78,13 @@ class TrainerBotDialog(QDialog):
                     won = match.get("winner") != match.get("opponent")
                     show_bot_battle_result(match.get("opponent", "trainer"), won)
 
-    def _bot_widget(self, bot, match=None, pvp_state=None):
+    def _bot_widget(self, bot, match=None, pvp_state=None, battle_enabled=True):
         widget = QWidget()
         row = QHBoxLayout(widget)
         sprite = QLabel()
-        sprite_path = trainer_sprites_path / f"{bot.get('trainer_sprite', '')}.png"
+        profile = (match or {}).get("opponent_trainer") or {}
+        sprite_name = bot.get("trainer_sprite") or profile.get("sprite", "")
+        sprite_path = trainer_sprites_path / f"{sprite_name}.png"
         if sprite_path.exists():
             sprite.setPixmap(QPixmap(str(sprite_path)).scaled(72, 72, Qt.AspectRatioMode.KeepAspectRatio))
         else:
@@ -91,7 +109,7 @@ class TrainerBotDialog(QDialog):
         text.setTextFormat(Qt.TextFormat.RichText)
         row.addWidget(text, 1)
         challenge = QPushButton("Challenge")
-        challenge.setEnabled(not bot.get("in_match", False))
+        challenge.setEnabled(battle_enabled and not bot.get("in_match", False))
         challenge.clicked.connect(lambda: self.challenge(bot))
         row.addWidget(challenge)
         if match and match.get("status") == "active":


### PR DESCRIPTION
## Summary\n- show non-bot friends in the Trainer Battles window\n- allow friend challenges when human PvP is enabled\n- reuse active match trainer portraits for friend rows\n\n## Validation\n- py -3 -m pytest -q (26 passed)\n- Python syntax check