### PR TITLE
fix: accept legacy credential file format

### DIFF
--- a/src/Ankimon/functions/multiplayer_functions.py
+++ b/src/Ankimon/functions/multiplayer_functions.py
@@ -47,6 +47,16 @@ def _headers():
                 credentials = json.load(handle)
         except (FileNotFoundError, json.JSONDecodeError) as exc:
             raise MultiplayerClientError("Set up your Ankimon username and API key first.") from exc
+        if isinstance(credentials, list):
+            # Older leaderboard versions stored username and api_key as
+            # separate objects in a list.
+            merged = {}
+            for entry in credentials:
+                if isinstance(entry, dict):
+                    merged.update(entry)
+            credentials = merged
+        if not isinstance(credentials, dict):
+            raise MultiplayerClientError("Your Ankimon credentials file has an invalid format.")
         username = credentials.get("username")
         api_key = credentials.get("api_key")
         if not username or not api_key:

--- a/src/Ankimon/functions/raid_functions.py
+++ b/src/Ankimon/functions/raid_functions.py
@@ -46,6 +46,17 @@ def _auth_headers():
                 "(the same credentials used for the leaderboard) before joining a raid."
             )
 
+        if isinstance(credentials, list):
+            # Older leaderboard versions stored username and api_key as
+            # separate objects in a list.
+            merged = {}
+            for entry in credentials:
+                if isinstance(entry, dict):
+                    merged.update(entry)
+            credentials = merged
+        if not isinstance(credentials, dict):
+            raise RaidClientError("Your Ankimon credentials file has an invalid format.")
+
         username = credentials.get("username")
         api_key = credentials.get("api_key")
         if not username or not api_key:


### PR DESCRIPTION
## Summary\n- accept legacy list-of-objects credentials\n- preserve current object format\n- apply compatibility to multiplayer and raid clients\n\n## Validation\n- py -3 -m pytest -q (26 passed)