### PR TITLE
feat: join server-managed raids

### DIFF
--- a/src/Ankimon/functions/raid_functions.py
+++ b/src/Ankimon/functions/raid_functions.py
@@ -66,8 +66,8 @@ def _auth_headers():
         _credentials_cache = (credentials_mtime, username, api_key)
 
     return username, {
+        "Authorization": f"Bearer {api_key}",
         "X-Ankimon-Username": username,
-        "X-Ankimon-Api-Key": api_key,
         "Content-Type": "application/json",
     }
 
@@ -96,30 +96,50 @@ def _request(method, path, json_body=None):
         raise RaidClientError("Raid server returned an unexpected (non-JSON) response.")
 
 
+def _normalize_raid_state(state):
+    """Adapt the multiplayer API raid shape to RaidSession's UI shape."""
+    raid = state.get("raid") if isinstance(state, dict) else None
+    if not raid:
+        return {}
+    participants = {}
+    for entry in raid.get("party", []):
+        username = entry.get("username", "Trainer")
+        participants[username] = {
+            "username": username,
+            "damage_dealt": entry.get("damage", 0),
+        }
+    return {
+        "id": raid.get("code"),
+        "boss_name": raid.get("boss_name"),
+        "boss_level": raid.get("boss_level"),
+        "max_hp": raid.get("boss_max_hp"),
+        "hp": raid.get("boss_hp"),
+        "participants": participants,
+    }
 def create_raid(boss_name, boss_level, max_hp):
-    """Create a new raid boss on the server. Returns the raid state dict."""
-    return _request("POST", "/raids", {
-        "boss_name": boss_name,
-        "boss_level": boss_level,
-        "max_hp": max_hp,
-    })
+    raise RaidClientError("Raids are created by the server. Choose an available room.")
 
 
 def list_active_raids():
-    """Return the list of raids whose boss hasn't been defeated yet."""
-    return _request("GET", "/raids")
+    """Return server-created rooms whose boss hasn't been defeated yet."""
+    return _request("GET", "/v1/raids").get("rooms", [])
 
 
 def poll_raid_state(raid_id):
-    """Fetch the current state of one raid (boss HP, participants)."""
-    return _request("GET", f"/raids/{raid_id}")
+    """Fetch the authenticated player's current raid state."""
+    return _normalize_raid_state(_request("GET", "/v1/state"))
 
 
 def join_raid(raid_id):
     # No "username" field in the body - the server takes the participant's
     # identity from the authenticated X-Ankimon-Username header, so a
     # request body can't claim to act as someone else.
-    return _request("POST", f"/raids/{raid_id}/join", {})
+    return _normalize_raid_state(_request("POST", f"/v1/raids/{raid_id}/join", {}))
+
+
+def leave_raid(raid_id):
+    """Leave the current server-managed raid room."""
+    return _request("POST", f"/v1/raids/{raid_id}/leave", {})
 
 
 def send_attack(raid_id, damage, level, base_power, atk_stat, def_stat):
@@ -130,13 +150,9 @@ def send_attack(raid_id, damage, level, base_power, atk_stat, def_stat):
     Returns the server's response, whose `damage_accepted` field is what was
     actually applied.
     """
-    return _request("POST", f"/raids/{raid_id}/attack", {
-        "damage": int(damage),
-        "level": int(level),
-        "base_power": int(base_power),
-        "atk_stat": int(atk_stat),
-        "def_stat": int(def_stat),
-    })
+    # Raid damage is credited by /v1/events:batch when a card is reviewed.
+    # This compatibility call only refreshes the authoritative state.
+    return poll_raid_state(raid_id)
 
 
 def try_send_attack(raid_id, damage, level, base_power, atk_stat, def_stat):

--- a/src/Ankimon/pyobj/raid_dialog.py
+++ b/src/Ankimon/pyobj/raid_dialog.py
@@ -2,6 +2,7 @@ from PyQt6.QtWidgets import (
     QDialog, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit, QSpinBox,
     QPushButton, QListWidget, QProgressBar, QTabWidget, QWidget, QMessageBox,
 )
+from PyQt6.QtCore import Qt
 from aqt import mw
 
 from ..functions import raid_functions
@@ -21,7 +22,7 @@ class RaidDialog(QDialog):
         self.tabs = QTabWidget()
         layout.addWidget(self.tabs)
 
-        self.tabs.addTab(self._build_create_tab(), "Create")
+        self.tabs.addTab(self._build_create_tab(), "Available raids")
         self.tabs.addTab(self._build_join_tab(), "Join")
 
         self.status_group = QWidget()
@@ -47,33 +48,19 @@ class RaidDialog(QDialog):
 
         layout.addWidget(self.status_group)
 
+        self.refresh_available_raids()
         self.refresh_status()
 
     def _build_create_tab(self):
         tab = QWidget()
         form = QVBoxLayout(tab)
-
-        self.boss_name_input = QLineEdit()
-        self.boss_name_input.setPlaceholderText("Boss name (e.g. Rayquaza)")
-
-        self.boss_level_input = QSpinBox()
-        self.boss_level_input.setRange(1, 100)
-        self.boss_level_input.setValue(50)
-
-        self.boss_hp_input = QSpinBox()
-        self.boss_hp_input.setRange(1, 100000)
-        self.boss_hp_input.setValue(500)
-
-        create_button = QPushButton("Create raid")
-        create_button.clicked.connect(self.create_raid)
-
-        form.addWidget(QLabel("Boss name"))
-        form.addWidget(self.boss_name_input)
-        form.addWidget(QLabel("Boss level"))
-        form.addWidget(self.boss_level_input)
-        form.addWidget(QLabel("Boss max HP"))
-        form.addWidget(self.boss_hp_input)
-        form.addWidget(create_button)
+        form.addWidget(QLabel("Raids are created automatically by the server."))
+        self.available_raids = QListWidget()
+        form.addWidget(self.available_raids)
+        self.available_raids.itemDoubleClicked.connect(self.join_available_room)
+        refresh_button = QPushButton("Refresh available raids")
+        refresh_button.clicked.connect(self.refresh_available_raids)
+        form.addWidget(refresh_button)
         return tab
 
     def _build_join_tab(self):
@@ -91,16 +78,27 @@ class RaidDialog(QDialog):
         form.addWidget(join_button)
         return tab
 
-    def create_raid(self):
-        boss_name = self.boss_name_input.text().strip()
-        if not boss_name:
-            QMessageBox.warning(self, "Ankimon Raid", "Enter a boss name first.")
-            return
+    def refresh_available_raids(self):
         try:
-            raid_state = raid_functions.create_raid(
-                boss_name, self.boss_level_input.value(), self.boss_hp_input.value()
+            rooms = raid_functions.list_active_raids()
+        except RaidClientError as e:
+            QMessageBox.warning(self, "Ankimon Raid", str(e))
+            return
+        self.available_raids.clear()
+        for room in rooms:
+            item = QListWidgetItem(
+                f"{room['boss_name']} Lv. {room['boss_level']} — "
+                f"{room['party_size']}/{room.get('capacity', 5)} trainers"
             )
-            raid_functions.join_raid(raid_state["id"])
+            item.setData(Qt.ItemDataRole.UserRole, room["code"])
+            self.available_raids.addItem(item)
+
+    def join_available_room(self, item):
+        self.join_room(item.data(Qt.ItemDataRole.UserRole))
+
+    def join_room(self, raid_id):
+        try:
+            raid_state = raid_functions.join_raid(raid_id)
             self.raid_session.start(raid_state)
             self.refresh_status()
         except RaidClientError as e:
@@ -119,6 +117,11 @@ class RaidDialog(QDialog):
             QMessageBox.warning(self, "Ankimon Raid", str(e))
 
     def leave_raid(self):
+        if self.raid_session.raid_id:
+            try:
+                raid_functions.leave_raid(self.raid_session.raid_id)
+            except RaidClientError as e:
+                QMessageBox.warning(self, "Ankimon Raid", str(e))
         self.raid_session.stop()
         self.refresh_status()
 


### PR DESCRIPTION
## Summary\n- remove player-facing raid creation controls\n- list and join server-created raid rooms\n- align raid client requests with the /v1 multiplayer API\n\n## Validation\n- py -3 -m pytest -q (26 passed)\n- Python syntax check