### PR TITLE
fix: enable server raids by default

### DIFF
--- a/src/Ankimon/config.json
+++ b/src/Ankimon/config.json
@@ -46,6 +46,11 @@
     "misc.discord_rich_presence": false,
     "misc.discord_rich_presence_text": 1,
 
+    "raid.enabled": true,
+    "raid.server_url": "http://localhost:8080",
+    "multiplayer.server_url": "http://localhost:8080",
+    "multiplayer.enabled": false,
+
     "trainer.name": "Ash",
     "trainer.sprite": "ash",
     "trainer.id": 0,

--- a/src/Ankimon/pyobj/settings.py
+++ b/src/Ankimon/pyobj/settings.py
@@ -67,7 +67,7 @@ class Settings:
 
         # Backfill raid settings for existing configs created before this feature
         if "raid.enabled" not in config:
-            config["raid.enabled"] = False
+            config["raid.enabled"] = True
             changed = True
         if "raid.server_url" not in config:
             config["raid.server_url"] = "http://localhost:8080"
@@ -127,7 +127,7 @@ class Settings:
                 "misc.leaderboard": False,
                 "misc.YouShallNotPass_Ankimon_News": False,
 
-                "raid.enabled": False,
+                "raid.enabled": True,
                 "raid.server_url": "http://localhost:8080",
                 "multiplayer.server_url": "http://localhost:8080",
                 "multiplayer.enabled": False,


### PR DESCRIPTION
## Summary\n- enable server-backed raids by default\n- include raid and multiplayer server settings in the shipped config\n\n## Validation\n- 26 addon tests passed\n- JSON config validation passed