### PR TITLE
Refresh raid lobby with multiplayer view

### DIFF
--- a/src/Ankimon/functions/raid_functions.py
+++ b/src/Ankimon/functions/raid_functions.py
@@ -110,6 +110,7 @@ def _normalize_raid_state(state):
         }
     return {
         "id": raid.get("code"),
+        "boss_id": raid.get("boss_id"),
         "boss_name": raid.get("boss_name"),
         "boss_level": raid.get("boss_level"),
         "max_hp": raid.get("boss_max_hp"),

--- a/src/Ankimon/pyobj/raid_dialog.py
+++ b/src/Ankimon/pyobj/raid_dialog.py
@@ -1,8 +1,9 @@
-from PyQt6.QtWidgets import (
-    QDialog, QVBoxLayout, QHBoxLayout, QLabel, QLineEdit, QSpinBox,
-    QPushButton, QListWidget, QListWidgetItem, QProgressBar, QTabWidget, QWidget, QMessageBox,
-)
 from PyQt6.QtCore import Qt
+from PyQt6.QtWidgets import (
+    QDialog, QGroupBox, QHBoxLayout, QLabel, QLineEdit, QListWidget,
+    QListWidgetItem, QProgressBar, QPushButton, QScrollArea, QVBoxLayout,
+    QMessageBox, QWidget,
+)
 from aqt import mw
 
 from ..functions import raid_functions
@@ -10,127 +11,157 @@ from ..functions.raid_functions import RaidClientError
 
 
 class RaidDialog(QDialog):
+    """Server-managed raid lobby using the multiplayer raid-boss view."""
+
     def __init__(self, raid_session, parent=mw):
         super().__init__(parent)
         self.raid_session = raid_session
+        self.setWindowTitle("Ankimon Multiplayer - Raid Boss")
+        self.setMinimumSize(420, 420)
 
-        self.setWindowTitle("Ankimon Raid")
-        self.setMinimumWidth(420)
+        body = QWidget()
+        layout = QVBoxLayout(body)
+        layout.addWidget(self._build_active_raid_group())
+        layout.addWidget(self._build_rooms_group(), stretch=1)
 
-        layout = QVBoxLayout(self)
-
-        self.tabs = QTabWidget()
-        layout.addWidget(self.tabs)
-
-        self.tabs.addTab(self._build_create_tab(), "Available raids")
-        self.tabs.addTab(self._build_join_tab(), "Join")
-
-        self.status_group = QWidget()
-        status_layout = QVBoxLayout(self.status_group)
-        self.status_label = QLabel("Not currently in a raid.")
-        self.hp_bar = QProgressBar()
-        self.hp_bar.setRange(0, 1)
-        self.hp_bar.setValue(0)
-        self.participants_list = QListWidget()
-        status_layout.addWidget(self.status_label)
-        status_layout.addWidget(self.hp_bar)
-        status_layout.addWidget(QLabel("Participants:"))
-        status_layout.addWidget(self.participants_list)
-
-        refresh_row = QHBoxLayout()
-        self.refresh_button = QPushButton("Refresh")
-        self.refresh_button.clicked.connect(self.refresh_status)
-        self.leave_button = QPushButton("Leave raid")
-        self.leave_button.clicked.connect(self.leave_raid)
-        refresh_row.addWidget(self.refresh_button)
-        refresh_row.addWidget(self.leave_button)
-        status_layout.addLayout(refresh_row)
-
-        layout.addWidget(self.status_group)
+        scroll = QScrollArea()
+        scroll.setWidget(body)
+        scroll.setWidgetResizable(True)
+        scroll.setFrameShape(QScrollArea.Shape.NoFrame)
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(0, 0, 0, 0)
+        outer.addWidget(scroll)
 
         self.refresh_available_raids()
         self.refresh_status()
 
-    def _build_create_tab(self):
-        tab = QWidget()
-        form = QVBoxLayout(tab)
-        form.addWidget(QLabel("Raids are created automatically by the server."))
+    def _build_active_raid_group(self):
+        group = QGroupBox("Active raid")
+        layout = QVBoxLayout(group)
+        self.status_label = QLabel("No active raid")
+        self.status_label.setStyleSheet("font-weight: bold; font-size: 14px;")
+        layout.addWidget(self.status_label)
+        self.hp_bar = QProgressBar()
+        self.hp_bar.setRange(0, 100)
+        self.hp_bar.setFormat("Boss HP: %p%")
+        layout.addWidget(self.hp_bar)
+        self.raid_info = QLabel("Join an open room below to battle together.")
+        self.raid_info.setWordWrap(True)
+        layout.addWidget(self.raid_info)
+        layout.addWidget(QLabel("Party contributions:"))
+        self.participants_list = QListWidget()
+        self.participants_list.setMaximumHeight(130)
+        layout.addWidget(self.participants_list)
+        controls = QHBoxLayout()
+        refresh_status = QPushButton("Refresh raid")
+        refresh_status.clicked.connect(self.refresh_status)
+        controls.addWidget(refresh_status)
+        self.leave_button = QPushButton("Leave raid")
+        self.leave_button.clicked.connect(self.leave_raid)
+        controls.addWidget(self.leave_button)
+        layout.addLayout(controls)
+        return group
+
+    def _build_rooms_group(self):
+        group = QGroupBox("Raid rooms")
+        layout = QVBoxLayout(group)
+        layout.addWidget(QLabel("Open raid rooms are created and replenished by the server:"))
         self.available_raids = QListWidget()
-        form.addWidget(self.available_raids)
         self.available_raids.itemDoubleClicked.connect(self.join_available_room)
-        refresh_button = QPushButton("Refresh available raids")
-        refresh_button.clicked.connect(self.refresh_available_raids)
-        form.addWidget(refresh_button)
-        return tab
+        layout.addWidget(self.available_raids, stretch=1)
 
-    def _build_join_tab(self):
-        tab = QWidget()
-        form = QVBoxLayout(tab)
+        room_controls = QHBoxLayout()
+        join_selected = QPushButton("Join selected room")
+        join_selected.clicked.connect(self.join_selected_room)
+        room_controls.addWidget(join_selected)
+        refresh = QPushButton("Refresh rooms")
+        refresh.clicked.connect(self.refresh_available_raids)
+        room_controls.addWidget(refresh)
+        layout.addLayout(room_controls)
 
+        code_row = QHBoxLayout()
         self.raid_id_input = QLineEdit()
-        self.raid_id_input.setPlaceholderText("Raid ID (shared by whoever created it)")
-
-        join_button = QPushButton("Join raid")
-        join_button.clicked.connect(self.join_raid)
-
-        form.addWidget(QLabel("Raid ID"))
-        form.addWidget(self.raid_id_input)
-        form.addWidget(join_button)
-        return tab
+        self.raid_id_input.setPlaceholderText("Raid code from a friend")
+        self.raid_id_input.returnPressed.connect(self.join_raid)
+        code_row.addWidget(self.raid_id_input)
+        join_code = QPushButton("Join by code")
+        join_code.clicked.connect(self.join_raid)
+        code_row.addWidget(join_code)
+        layout.addLayout(code_row)
+        return group
 
     def refresh_available_raids(self):
         try:
             rooms = raid_functions.list_active_raids()
-        except RaidClientError as e:
-            QMessageBox.warning(self, "Ankimon Raid", str(e))
+        except RaidClientError as exc:
+            self.available_raids.clear()
+            self.available_raids.addItem("Unable to load raid rooms")
+            QMessageBox.warning(self, "Ankimon Raid", str(exc))
             return
+
         self.available_raids.clear()
         for room in rooms:
+            boss = room.get("boss_name", "Raid boss")
+            level = room.get("boss_level", "?")
+            hp = room.get("boss_hp", 0)
+            max_hp = room.get("boss_max_hp", 0)
+            hp_pct = int(100 * hp / max_hp) if max_hp else 0
+            capacity = room.get("capacity", 5)
+            party = f"{room.get('party_size', 0)}/{capacity} trainers"
+            status = "full" if room.get("party_size", 0) >= capacity else "open"
             item = QListWidgetItem(
-                f"{room['boss_name']} Lv. {room['boss_level']} — "
-                f"{room['party_size']}/{room.get('capacity', 5)} trainers"
+                f"{boss} Lv. {level} - {hp_pct}% HP - {party} - {status}"
             )
-            item.setData(Qt.ItemDataRole.UserRole, room["code"])
+            item.setData(Qt.ItemDataRole.UserRole, room.get("code"))
             self.available_raids.addItem(item)
+        if not rooms:
+            self.available_raids.addItem("No open raid rooms right now.")
 
     def join_available_room(self, item):
-        self.join_room(item.data(Qt.ItemDataRole.UserRole))
+        raid_id = item.data(Qt.ItemDataRole.UserRole)
+        if raid_id:
+            self.join_room(raid_id)
+
+    def join_selected_room(self):
+        item = self.available_raids.currentItem()
+        if item is None:
+            QMessageBox.information(self, "Ankimon Raid", "Select an open raid room first.")
+            return
+        self.join_available_room(item)
 
     def join_room(self, raid_id):
         try:
             raid_state = raid_functions.join_raid(raid_id)
             self.raid_session.start(raid_state)
             self.refresh_status()
-        except RaidClientError as e:
-            QMessageBox.warning(self, "Ankimon Raid", str(e))
+            self.refresh_available_raids()
+        except RaidClientError as exc:
+            QMessageBox.warning(self, "Ankimon Raid", str(exc))
 
     def join_raid(self):
         raid_id = self.raid_id_input.text().strip()
         if not raid_id:
-            QMessageBox.warning(self, "Ankimon Raid", "Enter a raid ID first.")
+            QMessageBox.warning(self, "Ankimon Raid", "Enter a raid code first.")
             return
-        try:
-            raid_state = raid_functions.join_raid(raid_id)
-            self.raid_session.start(raid_state)
-            self.refresh_status()
-        except RaidClientError as e:
-            QMessageBox.warning(self, "Ankimon Raid", str(e))
+        self.join_room(raid_id)
 
     def leave_raid(self):
         if self.raid_session.raid_id:
             try:
                 raid_functions.leave_raid(self.raid_session.raid_id)
-            except RaidClientError as e:
-                QMessageBox.warning(self, "Ankimon Raid", str(e))
+            except RaidClientError as exc:
+                QMessageBox.warning(self, "Ankimon Raid", str(exc))
         self.raid_session.stop()
         self.refresh_status()
+        self.refresh_available_raids()
 
     def refresh_status(self):
         if not self.raid_session.active or not self.raid_session.raid_id:
-            self.status_label.setText("Not currently in a raid.")
-            self.hp_bar.setRange(0, 1)
+            self.status_label.setText("No active raid")
+            self.raid_info.setText("Join an open room below to battle together.")
             self.hp_bar.setValue(0)
             self.participants_list.clear()
+            self.leave_button.setEnabled(False)
             return
 
         try:
@@ -138,22 +169,24 @@ class RaidDialog(QDialog):
             self.raid_session.apply_state(raid_state)
             raid_functions.announce_completion(self.raid_session)
             self.raid_session.note_polled()
-        except RaidClientError as e:
-            self.status_label.setText(f"Couldn't refresh raid state: {e}")
+        except RaidClientError as exc:
+            self.raid_info.setText(f"Couldn't refresh raid state: {exc}")
             return
 
         defeated = self.raid_session.hp is not None and self.raid_session.hp <= 0
-        state_text = "Defeated!" if defeated else "In progress"
         self.status_label.setText(
-            f"{self.raid_session.boss_name} (Lv. {self.raid_session.boss_level}) "
-            f"- {self.raid_session.hp}/{self.raid_session.max_hp} HP - {state_text}\n"
-            f"Raid ID: {self.raid_session.raid_id}"
+            f"{self.raid_session.boss_name} (Lv. {self.raid_session.boss_level})"
         )
-        self.hp_bar.setRange(0, self.raid_session.max_hp or 1)
-        self.hp_bar.setValue(max(0, self.raid_session.hp or 0))
-
+        max_hp = self.raid_session.max_hp or 1
+        hp = self.raid_session.hp or 0
+        self.hp_bar.setValue(max(0, min(100, int(100 * hp / max_hp))))
+        state_text = "Defeated!" if defeated else "In progress"
+        self.raid_info.setText(
+            f"{hp}/{max_hp} HP - {state_text}<br>Raid code: {self.raid_session.raid_id}"
+        )
         self.participants_list.clear()
         for participant in self.raid_session.participants.values():
             self.participants_list.addItem(
-                f"{participant['username']}: {participant['damage_dealt']} damage dealt"
+                f"{participant['username']} - {participant['damage_dealt']} damage"
             )
+        self.leave_button.setEnabled(True)

--- a/src/Ankimon/pyobj/raid_obj.py
+++ b/src/Ankimon/pyobj/raid_obj.py
@@ -10,6 +10,7 @@ class RaidSession:
     def __init__(self):
         self.active = False
         self.raid_id = None
+        self.boss_id = None
         self.boss_name = None
         self.boss_level = None
         self.max_hp = None
@@ -28,6 +29,7 @@ class RaidSession:
     def stop(self):
         self.active = False
         self.raid_id = None
+        self.boss_id = None
         self.boss_name = None
         self.boss_level = None
         self.max_hp = None
@@ -41,6 +43,7 @@ class RaidSession:
         was_active = self.active
         previous_hp = self.hp
         self.raid_id = raid_state.get("id", self.raid_id)
+        self.boss_id = raid_state.get("boss_id", self.boss_id)
         self.boss_name = raid_state.get("boss_name", self.boss_name)
         self.boss_level = raid_state.get("boss_level", self.boss_level)
         self.max_hp = raid_state.get("max_hp", self.max_hp)

--- a/src/Ankimon/pyobj/reviewer_obj.py
+++ b/src/Ankimon/pyobj/reviewer_obj.py
@@ -1,3 +1,5 @@
+import copy
+
 from aqt import gui_hooks, mw, utils
 from aqt.utils import showInfo
 from ..functions.pokemon_functions import find_experience_for_level
@@ -13,6 +15,7 @@ class Reviewer_Manager:
         self.settings = settings_obj
         self.main_pokemon = main_pokemon
         self.enemy_pokemon = enemy_pokemon
+        self._battle_enemy = enemy_pokemon
         self.ankimon_tracker = ankimon_tracker
         self.life_bar_injected = False
         self.seconds = 0
@@ -36,6 +39,23 @@ class Reviewer_Manager:
                     return path
         return None
 
+    def _sync_raid_boss_display(self):
+        """Render the active raid boss without replacing battle mechanics."""
+        session = getattr(mw, "raid_session_obj", None)
+        if not session or not session.active or not session.boss_id:
+            self.enemy_pokemon = self._battle_enemy
+            return
+        enemy = copy.copy(self._battle_enemy)
+        enemy.id = int(session.boss_id)
+        enemy.name = session.boss_name or enemy.name
+        enemy.level = session.boss_level or enemy.level
+        enemy.hp = session.hp if session.hp is not None else enemy.hp
+        enemy.max_hp = session.max_hp or enemy.max_hp
+        enemy.current_hp = enemy.hp
+        enemy.shiny = False
+        enemy.battle_status = "fighting"
+        self.enemy_pokemon = enemy
+
     def _trainer_image_html(self):
         path = self._opponent_trainer_sprite()
         if not path:
@@ -50,6 +70,7 @@ class Reviewer_Manager:
         self.life_bar_injected = False
 
     def inject_life_bar(self, web_content, context):
+        self._sync_raid_boss_display()
         if int(self.settings.get("gui.show_mainpkmn_in_reviewer", 1)) < 3:
             if self.settings.get('gui.reviewer_image_gif', 1) == False:
                 pokemon_image_file = self.enemy_pokemon.get_sprite_path("front", "png")
@@ -184,6 +205,7 @@ class Reviewer_Manager:
         return web_content
 
     def update_life_bar(self, reviewer, card, ease):
+        self._sync_raid_boss_display()
         if int(self.settings.get("gui.show_mainpkmn_in_reviewer", 1)) < 3:
             self.ankimon_tracker.check_pokecoll_in_list()
             if self.settings.get('gui.reviewer_image_gif', 1) == False:

--- a/src/Ankimon/pyobj/trainer_bot_dialog.py
+++ b/src/Ankimon/pyobj/trainer_bot_dialog.py
@@ -52,7 +52,9 @@ class TrainerBotDialog(QDialog):
                  candidate.get("opponent_is_bot")),
                 None,
             )
-            self.roster.setItemWidget(item, self._bot_widget(bot, match, pvp_state))
+            widget = self._bot_widget(bot, match, pvp_state)
+            item.setSizeHint(widget.sizeHint())
+            self.roster.setItemWidget(item, widget)
 
         human_enabled = pvp_state.get("human_enabled", False)
         for friend in state.get("friends", []):
@@ -66,9 +68,9 @@ class TrainerBotDialog(QDialog):
                  not candidate.get("opponent_is_bot")),
                 None,
             )
-            self.roster.setItemWidget(
-                item, self._bot_widget(friend, match, pvp_state, human_enabled)
-            )
+            widget = self._bot_widget(friend, match, pvp_state, human_enabled)
+            item.setSizeHint(widget.sizeHint())
+            self.roster.setItemWidget(item, widget)
 
         for match in state.get("pvp", {}).get("matches", []):
             if match.get("status") == "finished":
@@ -80,6 +82,7 @@ class TrainerBotDialog(QDialog):
 
     def _bot_widget(self, bot, match=None, pvp_state=None, battle_enabled=True):
         widget = QWidget()
+        widget.setMinimumHeight(84)
         row = QHBoxLayout(widget)
         sprite = QLabel()
         profile = (match or {}).get("opponent_trainer") or {}


### PR DESCRIPTION
Ports the Claude-era raid boss lobby hierarchy into the current addon. Shows the active boss, percentage HP, raid code, party contributions, and server-managed open rooms with capacity/status. Adds join-selected, double-click, join-by-code, refresh, and leave actions. Removes player-facing raid creation controls. Verification: py -3 -m pytest -q (26 passed); py -3 -m compileall -q src/Ankimon/pyobj/raid_dialog.py.