### PR TITLE
Separate raid and trainer reviewer opponents

### DIFF
--- a/src/Ankimon/__init__.py
+++ b/src/Ankimon/__init__.py
@@ -1615,15 +1615,20 @@ def activate_trainer_battle():
 
     opponent = match.get("opponent_pokemon") or {}
     name = str(opponent.get("name") or "Rattata")
+    lookup_name = name.lower()
     pokemon_id = int(opponent.get("id") or 19)
     level = max(1, int(opponent.get("level") or 5))
     try:
-        stats = search_pokedex(name, "baseStats")
-        types = search_pokedex(name, "types")
-        abilities = search_pokedex(name, "abilities")
+        stats = search_pokedex(lookup_name, "baseStats")
+        if not isinstance(stats, dict) or "hp" not in stats:
+            raise ValueError(f"no base stats found for {lookup_name}")
+        types = search_pokedex(lookup_name, "types")
+        abilities = search_pokedex(lookup_name, "abilities")
         numeric_abilities = [value for key, value in (abilities or {}).items() if str(key).isdigit()]
         ability = random.choice(numeric_abilities) if numeric_abilities else "No Ability"
-        attacks = get_all_pokemon_moves(name, level)
+        attacks = get_all_pokemon_moves(lookup_name, level)
+        if not attacks:
+            attacks = ["Tackle"]
         attacks = attacks if len(attacks) <= 4 else random.sample(attacks, 4)
         iv = {key: 15 for key in ("hp", "atk", "def", "spa", "spd", "spe")}
         ev = {key: 0 for key in ("hp", "atk", "def", "spa", "spd", "spe")}
@@ -1639,7 +1644,7 @@ def activate_trainer_battle():
             growth_rate=search_pokeapi_db_by_id(pokemon_id, "growth_rate"),
             ev=ev,
             iv=iv,
-            gender=pick_random_gender(name),
+            gender=pick_random_gender(lookup_name),
             battle_status="fighting",
             tier="Normal",
             shiny=False,

--- a/src/Ankimon/__init__.py
+++ b/src/Ankimon/__init__.py
@@ -1664,10 +1664,23 @@ def activate_trainer_battle():
 
 mw.activate_trainer_battle = activate_trainer_battle
 
+
+def deactivate_trainer_battle():
+    """Leave trainer mode and resume normal wild encounters."""
+    if getattr(enemy_pokemon, "trainer_match_id", None) is None:
+        return
+    enemy_pokemon.trainer_match_id = None
+    new_pokemon()
+
+
+mw.deactivate_trainer_battle = deactivate_trainer_battle
+
 # Hook into Anki's card review event
 def on_review_card(*args):
     try:
         trainer_battle_active = activate_trainer_battle()
+        if not trainer_battle_active and getattr(enemy_pokemon, "trainer_match_id", None):
+            deactivate_trainer_battle()
         if settings_obj.get("multiplayer.enabled", False):
             multiplayer_functions.queue_review(
                 args,

--- a/src/Ankimon/__init__.py
+++ b/src/Ankimon/__init__.py
@@ -1475,6 +1475,7 @@ def get_random_starter():
 
 def new_pokemon():
     try:
+        enemy_pokemon.trainer_match_id = None
         # new pokemon
         gender = None
         name, id, level, ability, type, stats, enemy_attacks, base_experience, growth_rate, ev, iv, gender, battle_status, battle_stats, tier, ev_yield, shiny = generate_random_pokemon()
@@ -1596,9 +1597,77 @@ reviewer_obj = Reviewer_Manager(
     ankimon_tracker=ankimon_tracker_obj,
 )
 
+
+def activate_trainer_battle():
+    """Load the selected trainer's Pokemon into the real battle engine."""
+    state = getattr(mw, "multiplayer_state", {}) or {}
+    match = next(
+        (candidate for candidate in state.get("pvp", {}).get("matches", [])
+         if candidate.get("status") == "active"
+         and candidate.get("opponent_pokemon")),
+        None,
+    )
+    if not match:
+        return False
+    match_id = match.get("id")
+    if getattr(enemy_pokemon, "trainer_match_id", None) == match_id:
+        return True
+
+    opponent = match.get("opponent_pokemon") or {}
+    name = str(opponent.get("name") or "Rattata")
+    pokemon_id = int(opponent.get("id") or 19)
+    level = max(1, int(opponent.get("level") or 5))
+    try:
+        stats = search_pokedex(name, "baseStats")
+        types = search_pokedex(name, "types")
+        abilities = search_pokedex(name, "abilities")
+        numeric_abilities = [value for key, value in (abilities or {}).items() if str(key).isdigit()]
+        ability = random.choice(numeric_abilities) if numeric_abilities else "No Ability"
+        attacks = get_all_pokemon_moves(name, level)
+        attacks = attacks if len(attacks) <= 4 else random.sample(attacks, 4)
+        iv = {key: 15 for key in ("hp", "atk", "def", "spa", "spd", "spe")}
+        ev = {key: 0 for key in ("hp", "atk", "def", "spa", "spd", "spe")}
+        enemy_pokemon.update_stats(
+            name=name,
+            id=pokemon_id,
+            level=level,
+            ability=ability,
+            type=types,
+            stats=stats,
+            attacks=attacks,
+            base_experience=search_pokeapi_db_by_id(pokemon_id, "base_experience"),
+            growth_rate=search_pokeapi_db_by_id(pokemon_id, "growth_rate"),
+            ev=ev,
+            iv=iv,
+            gender=pick_random_gender(name),
+            battle_status="fighting",
+            tier="Normal",
+            shiny=False,
+        )
+    except Exception as exc:
+        logger.log("error", f"Could not load trainer Pokemon {name}: {exc}")
+        enemy_pokemon.name = name
+        enemy_pokemon.id = pokemon_id
+        enemy_pokemon.level = level
+
+    calculated_hp = enemy_pokemon.calculate_max_hp()
+    enemy_pokemon.max_hp = int(opponent.get("max_hp") or calculated_hp)
+    enemy_pokemon.hp = int(opponent.get("hp") or enemy_pokemon.max_hp)
+    enemy_pokemon.current_hp = enemy_pokemon.hp
+    enemy_pokemon.trainer_match_id = match_id
+    reviewer_obj._battle_enemy = enemy_pokemon
+    reviewer_obj.enemy_pokemon = enemy_pokemon
+    ankimon_tracker_obj.pokemon_encouter = max(1, ankimon_tracker_obj.pokemon_encouter)
+    ankimon_tracker_obj.randomize_battle_scene()
+    return True
+
+
+mw.activate_trainer_battle = activate_trainer_battle
+
 # Hook into Anki's card review event
 def on_review_card(*args):
     try:
+        trainer_battle_active = activate_trainer_battle()
         if settings_obj.get("multiplayer.enabled", False):
             multiplayer_functions.queue_review(
                 args,
@@ -1840,6 +1909,13 @@ def on_review_card(*args):
                             enemy_pokemon.hp = 0
                             msg += translator.translate("pokemon_fainted", enemy_pokemon_name=enemy_pokemon.name.capitalize())
                             
+                    if trainer_battle_active:
+                        try:
+                            multiplayer_functions.submit_turn(
+                                enemy_pokemon.trainer_match_id, random_attack
+                            )
+                        except multiplayer_functions.MultiplayerClientError as exc:
+                            logger.log("error", f"Trainer battle sync failed: {exc}")
                     tooltipWithColour(msg, color)
                     if dmg > 0:
                         reviewer_obj.seconds = int(settings_obj.compute_special_variable("animate_time"))
@@ -1859,6 +1935,15 @@ def on_review_card(*args):
 
             if enemy_pokemon.hp < 1:
                 enemy_pokemon.hp = 0
+
+                if trainer_battle_active:
+                    opponent_name = (getattr(enemy_pokemon, "name", None) or "trainer").capitalize()
+                    raid_functions.show_bot_battle_result(opponent_name, True, enemy_pokemon.name)
+                    enemy_pokemon.trainer_match_id = None
+                    ankimon_tracker_obj.general_card_count_for_battle = 0
+                    new_pokemon()
+                    trainer_battle_active = False
+                    return
                 
                 # New automatic battle handling
                 auto_battle_setting = int(settings_obj.get("battle.automatic_battle", 0))

--- a/src/Ankimon/functions/create_css_for_reviewer.py
+++ b/src/Ankimon/functions/create_css_for_reviewer.py
@@ -3,8 +3,8 @@ def create_css_for_reviewer(show_mainpkmn_in_reviewer, pokemon_hp_percent, hp_ba
     css += """
     #OpponentTrainerImage {
         position: fixed;
-        right: 108px;
-        bottom: 112px;
+        right: 10px;
+        top: 10px;
         z-index: 10000;
         width: 64px;
         height: 64px;
@@ -18,6 +18,31 @@ def create_css_for_reviewer(show_mainpkmn_in_reviewer, pokemon_hp_percent, hp_ba
         object-fit: contain;
         image-rendering: pixelated;
     }
+    #RaidBossImage {
+        position: fixed;
+        right: 10px;
+        top: 10px;
+        z-index: 10000;
+        width: 116px;
+        min-height: 96px;
+        padding: 4px;
+        color: white;
+        background: rgba(54, 54, 56, 0.82);
+        border: 1px solid rgba(255, 210, 80, 0.9);
+        border-radius: 8px;
+        text-align: center;
+        font-size: 11px;
+        font-weight: bold;
+    }
+    #RaidBossImage img {
+        display: block;
+        width: 72px;
+        height: 72px;
+        margin: 0 auto;
+        object-fit: contain;
+        image-rendering: pixelated;
+    }
+    #RaidBossLabel { line-height: 1.25; }
     """
     if show_mainpkmn_in_reviewer == 0:
         css += f"""

--- a/src/Ankimon/functions/multiplayer_functions.py
+++ b/src/Ankimon/functions/multiplayer_functions.py
@@ -108,6 +108,11 @@ def submit_turn(match_id, move=None):
     return _request("POST", f"/v1/matches/{match_id}/turns", body)
 
 
+def cancel_match(match_id):
+    """Cancel an open trainer battle without awarding a winner."""
+    return _request("POST", f"/v1/matches/{match_id}/cancel", {})
+
+
 def queue_review(reviewer_args, level, active_pokemon=None):
     """Queue one Anki review and flush in small batches.
 

--- a/src/Ankimon/pyobj/reviewer_obj.py
+++ b/src/Ankimon/pyobj/reviewer_obj.py
@@ -43,7 +43,7 @@ class Reviewer_Manager:
         state = getattr(mw, "multiplayer_state", {}) or {}
         return next(
             (match for match in state.get("pvp", {}).get("matches", [])
-             if match.get("status") in {"active", "pending"}
+             if match.get("status") == "active"
              and match.get("opponent_pokemon")),
             None,
         )

--- a/src/Ankimon/pyobj/reviewer_obj.py
+++ b/src/Ankimon/pyobj/reviewer_obj.py
@@ -39,12 +39,42 @@ class Reviewer_Manager:
                     return path
         return None
 
-    def _sync_raid_boss_display(self):
-        """Render the active raid boss without replacing battle mechanics."""
+    def _active_trainer_match(self):
+        state = getattr(mw, "multiplayer_state", {}) or {}
+        return next(
+            (match for match in state.get("pvp", {}).get("matches", [])
+             if match.get("status") in {"active", "pending"}
+             and match.get("opponent_pokemon")),
+            None,
+        )
+
+    def _sync_opponent_display(self):
+        """Use a trainer battle Pokemon, while keeping raid bosses separate."""
+        match = self._active_trainer_match()
+        if match:
+            pokemon = match.get("opponent_pokemon") or {}
+            enemy = copy.copy(self._battle_enemy)
+            try:
+                enemy.id = int(pokemon.get("id", enemy.id))
+            except (TypeError, ValueError):
+                pass
+            enemy.name = pokemon.get("name") or enemy.name
+            enemy.level = pokemon.get("level") or enemy.level
+            enemy.hp = pokemon.get("hp", enemy.hp)
+            enemy.max_hp = pokemon.get("max_hp") or enemy.max_hp
+            enemy.current_hp = enemy.hp
+            enemy.shiny = False
+            enemy.battle_status = "fighting"
+            self.enemy_pokemon = enemy
+            return
+
+        self.enemy_pokemon = self._battle_enemy
+
+    def _raid_boss_html(self):
+        """Return a separate top-right raid boss card for the reviewer."""
         session = getattr(mw, "raid_session_obj", None)
         if not session or not session.active or not session.boss_id:
-            self.enemy_pokemon = self._battle_enemy
-            return
+            return ""
         enemy = copy.copy(self._battle_enemy)
         enemy.id = int(session.boss_id)
         enemy.name = session.boss_name or enemy.name
@@ -53,8 +83,13 @@ class Reviewer_Manager:
         enemy.max_hp = session.max_hp or enemy.max_hp
         enemy.current_hp = enemy.hp
         enemy.shiny = False
-        enemy.battle_status = "fighting"
-        self.enemy_pokemon = enemy
+        image = get_image_as_base64(enemy.get_sprite_path("front", "png"))
+        return (
+            '<div id="RaidBossImage" class="Ankimon">'
+            f'<img src="data:image/png;base64,{image}" alt="Raid boss">'
+            f'<div id="RaidBossLabel">{enemy.name} Lv. {enemy.level}<br>'
+            f'HP: {enemy.hp}/{enemy.max_hp}</div></div>'
+        )
 
     def _trainer_image_html(self):
         path = self._opponent_trainer_sprite()
@@ -70,7 +105,7 @@ class Reviewer_Manager:
         self.life_bar_injected = False
 
     def inject_life_bar(self, web_content, context):
-        self._sync_raid_boss_display()
+        self._sync_opponent_display()
         if int(self.settings.get("gui.show_mainpkmn_in_reviewer", 1)) < 3:
             if self.settings.get('gui.reviewer_image_gif', 1) == False:
                 pokemon_image_file = self.enemy_pokemon.get_sprite_path("front", "png")
@@ -182,6 +217,7 @@ class Reviewer_Manager:
                     image_base64 = get_image_as_base64(pokemon_image_file)
                     web_content.body += f'<div id="PokeImage" class="Ankimon"><img src="data:image/png;base64,{image_base64}" alt="PokeImage style="animation: shake 0s ease;"></div>'
                     web_content.body += self._trainer_image_html()
+                    web_content.body += self._raid_boss_html()
                     if int(self.settings.get('gui.show_mainpkmn_in_reviewer', 1)) > 0:
                         image_base64_mypkmn = get_image_as_base64(main_pkmn_imagefile_path)
                         web_content.body += f'<div id="MyPokeImage" class="Ankimon"><img src="data:image/png;base64,{image_base64_mypkmn}" alt="MyPokeImage" style="animation: shake 0s ease;"></div>'
@@ -205,7 +241,7 @@ class Reviewer_Manager:
         return web_content
 
     def update_life_bar(self, reviewer, card, ease):
-        self._sync_raid_boss_display()
+        self._sync_opponent_display()
         if int(self.settings.get("gui.show_mainpkmn_in_reviewer", 1)) < 3:
             self.ankimon_tracker.check_pokecoll_in_list()
             if self.settings.get('gui.reviewer_image_gif', 1) == False:
@@ -267,6 +303,15 @@ class Reviewer_Manager:
                 hp_display_text = f"HP: {self.enemy_pokemon.hp}/{self.enemy_pokemon.max_hp}"
                 reviewer.web.eval('document.getElementById("name-display").innerText = "' + name_display_text + '";')
                 reviewer.web.eval('document.getElementById("hp-display").innerText = "' + hp_display_text + '";')
+                session = getattr(mw, "raid_session_obj", None)
+                if session and session.active:
+                    boss_name = (session.boss_name or "Raid boss").replace("`", "")
+                    boss_hp = session.hp if session.hp is not None else "?"
+                    boss_max_hp = session.max_hp or "?"
+                    reviewer.web.eval(
+                        "document.getElementById('RaidBossLabel').innerHTML = "
+                        f"`{boss_name} Lv. {session.boss_level}<br>HP: {boss_hp}/{boss_max_hp}`;"
+                    )
                 
                 # Update text colors based on current theme
                 reviewer.web.eval('updateTextColors();')

--- a/src/Ankimon/pyobj/trainer_bot_dialog.py
+++ b/src/Ankimon/pyobj/trainer_bot_dialog.py
@@ -37,6 +37,11 @@ class TrainerBotDialog(QDialog):
             return
         self._state = state
         pvp_state = state.get("pvp", {})
+        open_match = next(
+            (candidate for candidate in pvp_state.get("matches", [])
+             if candidate.get("status") in {"active", "pending"}),
+            None,
+        )
         self.attack_status.setText(
             f"Banked attacks: {pvp_state.get('banked_attacks', 0)} / "
             f"{pvp_state.get('max_banked_attacks', 3)}"
@@ -52,7 +57,7 @@ class TrainerBotDialog(QDialog):
                  candidate.get("opponent_is_bot")),
                 None,
             )
-            widget = self._bot_widget(bot, match, pvp_state)
+            widget = self._bot_widget(bot, match, pvp_state, not open_match)
             item.setSizeHint(widget.sizeHint())
             self.roster.setItemWidget(item, widget)
 
@@ -68,7 +73,9 @@ class TrainerBotDialog(QDialog):
                  not candidate.get("opponent_is_bot")),
                 None,
             )
-            widget = self._bot_widget(friend, match, pvp_state, human_enabled)
+            widget = self._bot_widget(
+                friend, match, pvp_state, human_enabled and not open_match
+            )
             item.setSizeHint(widget.sizeHint())
             self.roster.setItemWidget(item, widget)
 
@@ -116,6 +123,9 @@ class TrainerBotDialog(QDialog):
         challenge.clicked.connect(lambda: self.challenge(bot))
         row.addWidget(challenge)
         if match and match.get("status") == "active":
+            cancel = QPushButton("Cancel")
+            cancel.clicked.connect(lambda: self.cancel(match["id"]))
+            row.addWidget(cancel)
             attack = QPushButton("Attack")
             attack.setEnabled((pvp_state or {}).get("banked_attacks", 0) > 0)
             attack.clicked.connect(lambda: self.attack(match["id"]))
@@ -140,4 +150,16 @@ class TrainerBotDialog(QDialog):
         except multiplayer_functions.MultiplayerClientError as exc:
             QMessageBox.warning(self, "Trainer Battle", str(exc))
             return
+        self.refresh()
+
+    def cancel(self, match_id):
+        try:
+            multiplayer_functions.cancel_match(match_id)
+        except multiplayer_functions.MultiplayerClientError as exc:
+            QMessageBox.warning(self, "Trainer Battle", str(exc))
+            return
+        deactivate = getattr(mw, "deactivate_trainer_battle", None)
+        if deactivate:
+            deactivate()
+        QMessageBox.information(self, "Trainer Battle", "Trainer battle cancelled.")
         self.refresh()

--- a/src/Ankimon/pyobj/trainer_bot_dialog.py
+++ b/src/Ankimon/pyobj/trainer_bot_dialog.py
@@ -128,6 +128,9 @@ class TrainerBotDialog(QDialog):
         except multiplayer_functions.MultiplayerClientError as exc:
             QMessageBox.warning(self, "Trainer Battle", str(exc))
             return
+        activate = getattr(mw, "activate_trainer_battle", None)
+        if activate:
+            activate()
         QMessageBox.information(self, "Trainer Battle", f"{bot.get('trainer_name', bot.get('username', 'Trainer'))} accepts your challenge!\nAnswer a card to make your first move.")
         self.refresh()
 


### PR DESCRIPTION
Keep the normal encounter visible during raids and render the active raid boss separately in the reviewer top-right corner. When a bot or friend battle is active, use the match opponent Pokemon in place of the normal reviewer enemy and show the opponent trainer sprite. Verification: py -3 -m pytest -q (26 passed). Live addon files synced.