### PR TITLE
Fix trainer battle HP sync and team selection lock

### DIFF
--- a/src/Ankimon/gui_classes/pokemon_team_window.py
+++ b/src/Ankimon/gui_classes/pokemon_team_window.py
@@ -255,6 +255,19 @@ class PokemonTeamDialog(QDialog):
             
     def on_ok(self):
         """Store the selected Pokémon team and XP Share setting, then close the dialog"""
+        active_match = next(
+            (match for match in (getattr(mw, "multiplayer_state", {}) or {})
+             .get("pvp", {}).get("matches", [])
+             if match.get("status") == "active" and match.get("opponent_pokemon")),
+            None,
+        )
+        if active_match:
+            showWarning(
+                "Your Pokémon team is locked during a trainer battle. "
+                "Cancel the battle first if you want to change it; "
+                "cancelling will register the battle as a loss."
+            )
+            return
         #team = [frame_data['label'].text() for frame_data in self.pokemon_frames if frame_data['label'].text() != "Pokémon Not Selected"]
         team_data = []  # Initialize the list to store selected Pokémon
 

--- a/src/Ankimon/menu_buttons.py
+++ b/src/Ankimon/menu_buttons.py
@@ -345,9 +345,25 @@ def create_menu_actions(
         mw.translator.translate("choose_pokemon_team_button"), mw
     )
     pokemon_team_button.setMenuRole(QAction.MenuRole.NoRole)
-    pokemon_team_button.triggered.connect(
-        lambda: PokemonTeamDialog(settings_obj, logger)
-    )
+    def open_pokemon_team_dialog():
+        active_match = next(
+            (match for match in (getattr(mw, "multiplayer_state", {}) or {})
+             .get("pvp", {}).get("matches", [])
+             if match.get("status") == "active" and match.get("opponent_pokemon")),
+            None,
+        )
+        if active_match:
+            QMessageBox.warning(
+                mw,
+                "Trainer Battle in Progress",
+                "Your Pokémon team is locked during a trainer battle. "
+                "Cancel the battle first if you want to change your team; "
+                "cancelling will register the battle as a loss.",
+            )
+            return
+        PokemonTeamDialog(settings_obj, logger)
+
+    pokemon_team_button.triggered.connect(open_pokemon_team_dialog)
     game_menu.addAction(pokemon_team_button)
 
     # Button: File checker dialog

--- a/src/Ankimon/pyobj/reviewer_obj.py
+++ b/src/Ankimon/pyobj/reviewer_obj.py
@@ -60,8 +60,16 @@ class Reviewer_Manager:
                 pass
             enemy.name = pokemon.get("name") or enemy.name
             enemy.level = pokemon.get("level") or enemy.level
-            enemy.hp = pokemon.get("hp", enemy.hp)
-            enemy.max_hp = pokemon.get("max_hp") or enemy.max_hp
+            # The battle engine owns HP after a trainer match starts.  The
+            # server snapshot is only authoritative while initializing the
+            # display; reapplying it on every reviewer refresh would restore
+            # the opponent's pre-attack HP.
+            if getattr(self._battle_enemy, "trainer_match_id", None) == match.get("id"):
+                enemy.hp = self._battle_enemy.hp
+                enemy.max_hp = self._battle_enemy.max_hp
+            else:
+                enemy.hp = pokemon.get("hp", enemy.hp)
+                enemy.max_hp = pokemon.get("max_hp") or enemy.max_hp
             enemy.current_hp = enemy.hp
             enemy.shiny = False
             enemy.battle_status = "fighting"

--- a/src/Ankimon/pyobj/trainer_bot_dialog.py
+++ b/src/Ankimon/pyobj/trainer_bot_dialog.py
@@ -5,6 +5,7 @@ from aqt import mw
 
 from ..functions import multiplayer_functions
 from ..functions.raid_functions import show_bot_battle_result
+from ..gui_classes.pokemon_team_window import PokemonTeamDialog
 from ..resources import trainer_sprites_path
 
 
@@ -133,6 +134,24 @@ class TrainerBotDialog(QDialog):
         return widget
 
     def challenge(self, bot):
+        settings = getattr(mw, "settings_obj", None)
+        team = settings.get("trainer.team", []) if settings else []
+        if not isinstance(team, list) or not team:
+            QMessageBox.information(
+                self,
+                "Choose a team",
+                "You need to select a Pokémon team before challenging a trainer.",
+            )
+            if settings is not None:
+                PokemonTeamDialog(settings, getattr(mw, "logger", None), parent=mw)
+            team = settings.get("trainer.team", []) if settings else []
+            if not isinstance(team, list) or not team:
+                QMessageBox.warning(
+                    self,
+                    "Trainer Battle",
+                    "A trainer battle cannot start without a selected Pokémon team.",
+                )
+                return
         try:
             multiplayer_functions.challenge_bot(bot["challenge_value"])
         except multiplayer_functions.MultiplayerClientError as exc:


### PR DESCRIPTION
## Changes\n- preserve trainer opponent HP after local battle-engine attacks\n- require a selected team before challenging a trainer and open team selection automatically\n- lock team editing during active trainer battles with cancellation/loss guidance\n\n## Verification\n- py -3 -m pytest -q (26 passed)\n- Python compile checks passed\n- synced changed addon modules to the local Anki installation