### PR TITLE
Fix trainer battles, HP sync, and multi-Pokemon reviewer

### DIFF
--- a/src/Ankimon/__init__.py
+++ b/src/Ankimon/__init__.py
@@ -1706,6 +1706,8 @@ def on_review_card(*args):
         cry_counter = ankimon_tracker_obj.cry_counter
         card_counter = ankimon_tracker_obj.card_counter
         dmg = 0
+        trainer_match_state = None
+        finished_trainer_match = None
         reviewer_obj.seconds = 0
         reviewer_obj.myseconds = 0
         ankimon_tracker_obj.general_card_count_for_battle += 1
@@ -1929,7 +1931,7 @@ def on_review_card(*args):
                             
                     if trainer_battle_active:
                         try:
-                            multiplayer_functions.submit_turn(
+                            trainer_match_state = multiplayer_functions.submit_turn(
                                 enemy_pokemon.trainer_match_id, random_attack
                             )
                         except multiplayer_functions.MultiplayerClientError as exc:
@@ -1950,6 +1952,44 @@ def on_review_card(*args):
             # instead of silently resetting every time on_review_card runs.
             ankimon_tracker_obj.slp_counter = slp_counter
             enemy_pokemon.battle_status = battle_status
+
+            if trainer_battle_active and trainer_match_state:
+                trainer_match = next(
+                    (match for match in trainer_match_state.get("pvp", {}).get("matches", [])
+                     if match.get("id") == enemy_pokemon.trainer_match_id),
+                    None,
+                )
+                if trainer_match:
+                    opponent = trainer_match.get("opponent_pokemon") or {}
+                    # Bot damage is resolved by the server. Keep the local
+                    # engine aligned with that result so a local 0 HP does
+                    # not revive an active match on the next review.
+                    if trainer_match.get("status") == "active":
+                        try:
+                            enemy_pokemon.hp = max(0, int(opponent.get("hp", enemy_pokemon.hp)))
+                        except (TypeError, ValueError):
+                            pass
+                    elif trainer_match.get("status") == "finished":
+                        finished_trainer_match = trainer_match
+                        try:
+                            enemy_pokemon.hp = max(0, int(opponent.get("hp", 0)))
+                        except (TypeError, ValueError):
+                            enemy_pokemon.hp = 0
+
+            if finished_trainer_match:
+                opponent_name = (
+                    finished_trainer_match.get("opponent") or "trainer"
+                ).capitalize()
+                winner = finished_trainer_match.get("winner")
+                won = bool(winner) and winner != finished_trainer_match.get("opponent")
+                raid_functions.show_bot_battle_result(
+                    opponent_name, won, enemy_pokemon.name
+                )
+                enemy_pokemon.trainer_match_id = None
+                ankimon_tracker_obj.general_card_count_for_battle = 0
+                new_pokemon()
+                trainer_battle_active = False
+                return
 
             if enemy_pokemon.hp < 1:
                 enemy_pokemon.hp = 0

--- a/src/Ankimon/__init__.py
+++ b/src/Ankimon/__init__.py
@@ -1610,11 +1610,12 @@ def activate_trainer_battle():
     if not match:
         return False
     match_id = match.get("id")
-    if getattr(enemy_pokemon, "trainer_match_id", None) == match_id:
-        return True
-
     opponent = match.get("opponent_pokemon") or {}
     name = str(opponent.get("name") or "Rattata")
+    if (getattr(enemy_pokemon, "trainer_match_id", None) == match_id
+            and str(getattr(enemy_pokemon, "name", "")).lower() == name.lower()
+            and int(getattr(enemy_pokemon, "id", 0) or 0) == int(opponent.get("id") or 0)):
+        return True
     lookup_name = name.lower()
     pokemon_id = int(opponent.get("id") or 19)
     level = max(1, int(opponent.get("level") or 5))
@@ -1655,9 +1656,11 @@ def activate_trainer_battle():
         enemy_pokemon.id = pokemon_id
         enemy_pokemon.level = level
 
-    calculated_hp = enemy_pokemon.calculate_max_hp()
-    enemy_pokemon.max_hp = int(opponent.get("max_hp") or calculated_hp)
-    enemy_pokemon.hp = int(opponent.get("hp") or enemy_pokemon.max_hp)
+    calculated_hp = max(1, int(enemy_pokemon.calculate_max_hp()))
+    server_max_hp = max(1, int(opponent.get("max_hp") or calculated_hp))
+    server_hp = max(0, int(opponent.get("hp") or server_max_hp))
+    enemy_pokemon.max_hp = calculated_hp
+    enemy_pokemon.hp = min(calculated_hp, round(server_hp / server_max_hp * calculated_hp))
     enemy_pokemon.current_hp = enemy_pokemon.hp
     enemy_pokemon.trainer_match_id = match_id
     reviewer_obj._battle_enemy = enemy_pokemon
@@ -1749,7 +1752,9 @@ def on_review_card(*args):
             msg = ""
             msg += f"{multiplier}x {translator.translate('multiplier')}"
             #failed card = enemy attack
-            if ankimon_tracker_obj.pokemon_encouter > 0 and enemy_pokemon.hp > 0 and dmg_in_reviewer is True and multiplier < 1:
+            if (ankimon_tracker_obj.pokemon_encouter > 0 and enemy_pokemon.hp > 0
+                    and (dmg_in_reviewer is True or trainer_battle_active)
+                    and multiplier < 1):
                 msg += " \n "
                 try:
                     max_attempts = 3  # Set the maximum number of attempts
@@ -1975,6 +1980,12 @@ def on_review_card(*args):
                             enemy_pokemon.hp = max(0, int(opponent.get("hp", 0)))
                         except (TypeError, ValueError):
                             enemy_pokemon.hp = 0
+                    if trainer_match.get("status") == "active":
+                        # A server-side knockout may have selected the next
+                        # party slot. activate_trainer_battle reloads it
+                        # through the normal Pokemon engine when its name/id
+                        # differs from the current slot.
+                        activate_trainer_battle()
 
             if finished_trainer_match:
                 opponent_name = (

--- a/src/Ankimon/functions/create_css_for_reviewer.py
+++ b/src/Ankimon/functions/create_css_for_reviewer.py
@@ -18,6 +18,23 @@ def create_css_for_reviewer(show_mainpkmn_in_reviewer, pokemon_hp_percent, hp_ba
         object-fit: contain;
         image-rendering: pixelated;
     }
+    #OpponentTeam {
+        position: fixed;
+        right: 10px;
+        top: 82px;
+        z-index: 10000;
+        display: flex;
+        gap: 2px;
+        padding: 3px;
+        background: rgba(54, 54, 56, 0.7);
+        border-radius: 6px;
+    }
+    #OpponentTeam img {
+        width: 18px;
+        height: 18px;
+        object-fit: contain;
+        image-rendering: pixelated;
+    }
     #RaidBossImage {
         position: fixed;
         right: 10px;

--- a/src/Ankimon/pyobj/reviewer_obj.py
+++ b/src/Ankimon/pyobj/reviewer_obj.py
@@ -109,6 +109,25 @@ class Reviewer_Manager:
             f'alt="Opponent trainer"></div>'
         )
 
+    def _trainer_team_html(self):
+        """Show one Poké Ball for every Pokemon in the trainer's party."""
+        match = self._active_trainer_match()
+        if not match:
+            return ""
+        team = match.get("opponent_pokemon_team") or []
+        if not team:
+            team = [match.get("opponent_pokemon") or {}]
+        ball = get_image_as_base64(icon_path)
+        balls = []
+        for pokemon in team:
+            status = pokemon.get("status", "available")
+            opacity = "1" if status in {"active", "available"} else "0.35"
+            balls.append(
+                f'<img src="data:image/png;base64,{ball}" alt="{status}" '
+                f'style="opacity:{opacity}">' 
+            )
+        return f'<div id="OpponentTeam" class="Ankimon">{"".join(balls)}</div>'
+
     def reviewer_reset_life_bar_inject(self):
         self.life_bar_injected = False
 
@@ -225,6 +244,7 @@ class Reviewer_Manager:
                     image_base64 = get_image_as_base64(pokemon_image_file)
                     web_content.body += f'<div id="PokeImage" class="Ankimon"><img src="data:image/png;base64,{image_base64}" alt="PokeImage style="animation: shake 0s ease;"></div>'
                     web_content.body += self._trainer_image_html()
+                    web_content.body += self._trainer_team_html()
                     web_content.body += self._raid_boss_html()
                     if int(self.settings.get('gui.show_mainpkmn_in_reviewer', 1)) > 0:
                         image_base64_mypkmn = get_image_as_base64(main_pkmn_imagefile_path)
@@ -332,6 +352,11 @@ class Reviewer_Manager:
                 else:
                     pokeicon_html = ''
                 reviewer.web.eval(f'document.getElementById("PokeIcon").innerHTML = `{pokeicon_html}`;')
+                team_html = self._trainer_team_html()
+                reviewer.web.eval(
+                    f'{{const team = document.getElementById("OpponentTeam"); '
+                    f'if (team) team.outerHTML = `{team_html}`;}}'
+                )
                 reviewer.web.eval(f'document.getElementById("pokestatus").innerHTML = `{status_html}`;')
                 if int(self.settings.get('gui.show_mainpkmn_in_reviewer', 1)) > 0:
                     new_html_content_mainpkmn = f'<img src="data:image/png;base64,{image_base64_mainpkmn}" alt="MyPokeImage" style="animation: shake {self.myseconds}s ease;">'


### PR DESCRIPTION
## Changes\n- restore wild encounters after trainer matches finish\n- apply trainer battle damage through the existing addon battle engine\n- load actual Pokemon stats, calculated max HP, and attacks\n- render trainer party Poké Balls in the reviewer\n- load the next trainer Pokemon when the server advances the active party slot\n\n## Verification\n- addon: py -3 -m pytest -q (26 passed)\n- addon compile checks passed\n- server: go test ./... passed\n- changed addon files synced and SHA-256 verified in the local Anki installation