### PR TITLE
Fix UI callbacks, Pokemon defaults, and reviewer HP

### DIFF
--- a/src/Ankimon/__init__.py
+++ b/src/Ankimon/__init__.py
@@ -745,10 +745,15 @@ def tooltipWithColour(msg, color, x=0, y=20, xref=1, parent=None, width=0, heigh
         lab.setPalette(p)
         lab.show()
         lab.move(QPoint(x - round(lab.width() * 0.5 * xref), y))    
-        try:
-            QTimer.singleShot(period, lambda: lab.hide())
-        except:
-            QTimer.singleShot(3000, lambda: lab.hide())
+        def hide_label_safely():
+            try:
+                lab.hide()
+            except RuntimeError:
+                # The parent window may have destroyed the label before the
+                # delayed timer fires (for example when leaving the reviewer).
+                pass
+
+        QTimer.singleShot(period, hide_label_safely)
         logger.log_and_showinfo("game", msg)
 
 # Your random Pokémon generation function using the PokeAPI

--- a/src/Ankimon/pyobj/pokemon_obj.py
+++ b/src/Ankimon/pyobj/pokemon_obj.py
@@ -4,9 +4,9 @@ from ..resources import pkmnimgfolder
 import os
 
 class PokemonObject:
-    def __init__(self, name="Ditto", shiny=False, id=1, level=3, ability=["None"], type=["Normal"], current_hp=15, stats=None, attacks=None, base_experience=0, 
-                 growth_rate=None, hp=None, ev=None, iv=None, gender=None, battle_status="Fighting", xp=0, 
-                 position=0, nickname=None, moves=None, evos=None, tier = "Normal", ev_yield = {"hp": 1, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0}, friendship = 0, **kwargs):
+    def __init__(self, name="Ditto", shiny=False, id=1, level=3, ability=None, type=None, current_hp=15, stats=None, attacks=None, base_experience=0,
+                 growth_rate=None, hp=None, ev=None, iv=None, gender=None, battle_status="Fighting", xp=0,
+                 position=0, nickname=None, moves=None, evos=None, tier="Normal", ev_yield=None, friendship=0, **kwargs):
         self.name = name
         self.nickname = nickname or "" # Allow nickname to be set in the constructor
         self.shiny = shiny or False  # Default to False if None
@@ -14,15 +14,17 @@ class PokemonObject:
         self.level = level or 3  # Default to 3 if None
         self.ability = ability or ["None"]  # Default to ["None"] if None
         self.type = type or ["Normal"]
-        self.stats = stats or {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0}  # Default to empty dict if None
+        default_stats = {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0}
+        self.stats = {**default_stats, **(stats or {})}
         self.attacks = attacks or []  # Default to empty list if None
         self.base_experience = base_experience
         self.growth_rate = growth_rate
-        self.current_hp = current_hp or 15  # Ensure 'current_hp' is accepted here
-        self.ev = ev or {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0}  # Default to empty dict if None
-        self.iv = iv or {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0}  # Default to empty dict if None
-        self.ev_yield = ev_yield or {"hp": 0, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0}
-        self.hp = int((((((stats["hp"] + iv["hp"]) * 2 ) + (ev["hp"] / 4)) * level) / 100) + level + 10)
+        self.current_hp = current_hp if current_hp is not None else 15  # Preserve a saved 0 HP state
+        self.ev = {**default_stats, **(ev or {})}
+        self.iv = {**default_stats, **(iv or {})}
+        self.ev_yield = {"hp": 1, "atk": 0, "def": 0, "spa": 0, "spd": 0, "spe": 0}
+        self.ev_yield.update(ev_yield or {})
+        self.hp = int((((((self.stats["hp"] + self.iv["hp"]) * 2) + (self.ev["hp"] / 4)) * self.level) / 100) + self.level + 10)
         self.max_hp = self.hp
         self.gender = gender
         self.battle_status = battle_status

--- a/src/Ankimon/pyobj/reviewer_obj.py
+++ b/src/Ankimon/pyobj/reviewer_obj.py
@@ -147,9 +147,9 @@ class Reviewer_Manager:
                         side = "back"
                     main_pkmn_imagefile_path = self.main_pokemon.get_sprite_path(side, "gif")
             if int(self.settings.get('gui.show_mainpkmn_in_reviewer', 1)) > 0:
-                pokemon_hp_percent = int((self.enemy_pokemon.hp / self.enemy_pokemon.max_hp) * 50)
+                pokemon_hp_percent = int((self.enemy_pokemon.hp / max(1, self.enemy_pokemon.max_hp)) * 50)
             else:    
-                pokemon_hp_percent = int((self.enemy_pokemon.hp / self.enemy_pokemon.max_hp) * 100)
+                pokemon_hp_percent = int((self.enemy_pokemon.hp / max(1, self.enemy_pokemon.max_hp)) * 100)
             is_reviewer = mw.state == "review"
             # Inject CSS and the life bar only if not injected before and in the reviewer
             self.ankimon_tracker.check_pokecoll_in_list()
@@ -285,10 +285,10 @@ class Reviewer_Manager:
                         side = "back"
                     main_pkmn_imagefile_path = self.main_pokemon.get_sprite_path(side, "gif")
             if int(self.settings.get('gui.show_mainpkmn_in_reviewer', 1)) > 0:
-                pokemon_hp_percent = int((self.enemy_pokemon.hp / self.enemy_pokemon.max_hp) * 50)
+                pokemon_hp_percent = int((self.enemy_pokemon.hp / max(1, self.enemy_pokemon.max_hp)) * 50)
                 image_base64_mainpkmn = get_image_as_base64(main_pkmn_imagefile_path)
             else:    
-                pokemon_hp_percent = int((self.enemy_pokemon.hp / self.enemy_pokemon.max_hp) * 100)
+                pokemon_hp_percent = int((self.enemy_pokemon.hp / max(1, self.enemy_pokemon.max_hp)) * 100)
             image_base64 = get_image_as_base64(pokemon_image_file)
             # Determine the color based on the percentage
             if self.enemy_pokemon.hp < int(0.25 * self.enemy_pokemon.max_hp):
@@ -301,11 +301,11 @@ class Reviewer_Manager:
                 hp_color = "rgba(114, 230, 96, 0.7)"  # Green
 
             if int(self.settings.get('gui.show_mainpkmn_in_reviewer', 1)) > 0:
-                if self.main_pokemon.hp < int(0.25 * self.main_pokemon.hp):
+                if self.main_pokemon.hp < int(0.25 * self.main_pokemon.max_hp):
                     myhp_color = "rgba(255, 0, 0, 0.7)"  # Red
-                elif self.main_pokemon.hp < int(0.5 * self.main_pokemon.hp):
+                elif self.main_pokemon.hp < int(0.5 * self.main_pokemon.max_hp):
                     myhp_color = "rgba(255, 140, 0, 0.7)"  # Dark Orange
-                elif self.main_pokemon.hp < int(0.75 * self.main_pokemon.hp):
+                elif self.main_pokemon.hp < int(0.75 * self.main_pokemon.max_hp):
                     myhp_color = "rgba(255, 255, 0, 0.7)"  # Yellow
                 else:
                     myhp_color = "rgba(114, 230, 96, 0.7)"  # Green

--- a/tests/test_battle_functions.py
+++ b/tests/test_battle_functions.py
@@ -26,6 +26,16 @@ def make_pokemon(**overrides):
     return PokemonObject(**kwargs)
 
 
+def test_pokemon_defaults_are_constructible():
+    pokemon = PokemonObject()
+    assert pokemon.max_hp > 0
+    assert pokemon.hp == pokemon.max_hp
+
+
+def test_pokemon_preserves_zero_current_hp():
+    assert PokemonObject(current_hp=0).current_hp == 0
+
+
 class TestGetEffectiveness:
     def test_super_effective(self):
         # Water vs Fire is super effective (2x)


### PR DESCRIPTION
## Fixes\n- guard delayed tooltip cleanup when its parent destroys the label\n- make PokemonObject safe when optional stats are omitted\n- preserve saved 0 HP values\n- correct low-health color thresholds to use max HP\n- guard reviewer HP percentage calculations against zero max HP\n\n## Verification\n- py -3 -m pytest -q (28 passed)\n- addon compile checks passed\n- changed runtime files synced and SHA-256 verified in the live Anki installation