### PR TITLE
Fix reviewer bar settings and multiplayer error handling

### DIFF
--- a/src/Ankimon/__init__.py
+++ b/src/Ankimon/__init__.py
@@ -2719,8 +2719,9 @@ class TestWindow(QWidget):
         return image_label, msg_font
 
     def draw_hp_bar(self, x, y, h, w, hp, max_hp, painter):
-        pokemon_hp_percent = int((hp / max_hp) * 100)
-        hp_bar_value = int(w * (hp / max_hp))
+        safe_max_hp = max(1, max_hp)
+        pokemon_hp_percent = int((hp / safe_max_hp) * 100)
+        hp_bar_value = int(w * (hp / safe_max_hp))
         # Draw the HP bar
         if pokemon_hp_percent < 25:
             hp_color = QColor(255, 0, 0)  # Red

--- a/src/Ankimon/functions/create_css_for_reviewer.py
+++ b/src/Ankimon/functions/create_css_for_reviewer.py
@@ -335,7 +335,7 @@ def create_css_for_reviewer(show_mainpkmn_in_reviewer, pokemon_hp_percent, hp_ba
     if xp_bar_config is True:
             css += f"""
             #xp-bar {{
-            width: {int((main_pokemon.xp / int(experience_for_next_lvl)) * 100)}%; /* Replace with the actual percentage */
+            width: {int((main_pokemon.xp / max(1, int(experience_for_next_lvl))) * 100)}%; /* Replace with the actual percentage */
             height: 10px;
             background: linear-gradient(to right, 
                                         rgba(0, 191, 255, 0.7), /* Light Blue with transparency */

--- a/src/Ankimon/functions/multiplayer_functions.py
+++ b/src/Ankimon/functions/multiplayer_functions.py
@@ -82,7 +82,13 @@ def _request(method, path, body=None):
     except ValueError as exc:
         raise MultiplayerClientError("The multiplayer server returned invalid JSON.") from exc
     if response.status_code >= 400:
-        raise MultiplayerClientError(payload.get("error", f"Server error ({response.status_code})"))
+        if isinstance(payload, dict):
+            detail = payload.get("error")
+        else:
+            detail = None
+        raise MultiplayerClientError(detail or f"Server error ({response.status_code})")
+    if not isinstance(payload, dict):
+        raise MultiplayerClientError("The multiplayer server returned an invalid response.")
     # Reviewer rendering can reuse the latest state without another request.
     mw.multiplayer_state = payload
     return payload

--- a/src/Ankimon/functions/reviewer_iframe.py
+++ b/src/Ankimon/functions/reviewer_iframe.py
@@ -58,7 +58,7 @@ def create_iframe_html(main_pokemon, enemy_pokemon, settings_obj, textmsg):
     mainpokemon_attack = False
     enemypokemon_attack = False
     experience_for_next_lvl = int(find_experience_for_level(f"{main_pokemon.growth_rate}", int(main_pokemon.level), settings_obj))
-    xp_bar_width = int((int(main_pokemon.xp) / experience_for_next_lvl) * 100)
+    xp_bar_width = int((int(main_pokemon.xp) / max(1, experience_for_next_lvl)) * 100)
     ankimon_package = mw.addonManager.addonFromModule(__name__)
     general_url = f"""/_addons/{ankimon_package}/user_files/web/"""
     sprites_url = f"""/_addons/{ankimon_package}/user_files/sprites/"""

--- a/src/Ankimon/pyobj/reviewer_obj.py
+++ b/src/Ankimon/pyobj/reviewer_obj.py
@@ -154,7 +154,7 @@ class Reviewer_Manager:
             # Inject CSS and the life bar only if not injected before and in the reviewer
             self.ankimon_tracker.check_pokecoll_in_list()
             if not self.life_bar_injected and is_reviewer:
-                css = create_css_for_reviewer(int(self.settings.get('gui.show_mainpkmn_in_reviewer', 1)), pokemon_hp_percent, self.settings.get("battle.hp_bar_thickness", 2) * 4, int(self.settings.compute_special_variable('xp_bar_spacer')), self.settings.compute_special_variable('view_main_front'), int((self.main_pokemon.hp / self.main_pokemon.max_hp) * 50), int(self.settings.compute_special_variable('hp_only_spacer')), int(self.settings.compute_special_variable('wild_hp_spacer')), self.settings.get("gui.xp_bar_config", False), self.main_pokemon, int(find_experience_for_level(self.main_pokemon.growth_rate, self.main_pokemon.level, self.settings.get("remove_levelcap", False))), self.settings.compute_special_variable('xp_bar_location'))
+                css = create_css_for_reviewer(int(self.settings.get('gui.show_mainpkmn_in_reviewer', 1)), pokemon_hp_percent, self.settings.get("battle.hp_bar_thickness", 2) * 4, int(self.settings.compute_special_variable('xp_bar_spacer')), self.settings.compute_special_variable('view_main_front'), int((self.main_pokemon.hp / max(1, self.main_pokemon.max_hp)) * 50), int(self.settings.compute_special_variable('hp_only_spacer')), int(self.settings.compute_special_variable('wild_hp_spacer')), self.settings.get("gui.xp_bar_config", False), self.main_pokemon, int(find_experience_for_level(self.main_pokemon.growth_rate, self.main_pokemon.level, self.settings.get("remove_levelcap", False))), self.settings.compute_special_variable('xp_bar_location'))
                 css += inject_life_bar_css_1
                 css += inject_life_bar_css_2
                 
@@ -317,12 +317,13 @@ class Reviewer_Manager:
                 status_html = create_status_html(f"{self.enemy_pokemon.battle_status}", settings_obj=self.settings)
             if self.settings.get("gui.styling_in_reviewer", True) is True:
                 # Refresh the reviewer content to apply the updated life bar
-                reviewer.web.eval('document.getElementById("life-bar").style.width = "' + str(pokemon_hp_percent) + '%";')
-                reviewer.web.eval('document.getElementById("life-bar").style.background = "linear-gradient(to right, ' + str(hp_color) + ', ' + str(hp_color) + ' ' + '100' + '%, ' + 'rgba(54, 54, 56, 0.7)' + '100' + '%, ' + 'rgba(54, 54, 56, 0.7)' + ')";')
-                reviewer.web.eval('document.getElementById("life-bar").style.boxShadow = "0 0 10px ' + hp_color + ', 0 0 30px rgba(54, 54, 56, 1)";')
-                if self.settings.get("xp_bar_config", False) is True:
+                if self.settings.get("gui.hp_bar_config", True) is True:
+                    reviewer.web.eval('document.getElementById("life-bar").style.width = "' + str(pokemon_hp_percent) + '%";')
+                    reviewer.web.eval('document.getElementById("life-bar").style.background = "linear-gradient(to right, ' + str(hp_color) + ', ' + str(hp_color) + ' ' + '100' + '%, ' + 'rgba(54, 54, 56, 0.7)' + '100' + '%, ' + 'rgba(54, 54, 56, 0.7)' + ')";')
+                    reviewer.web.eval('document.getElementById("life-bar").style.boxShadow = "0 0 10px ' + hp_color + ', 0 0 30px rgba(54, 54, 56, 1)";')
+                if self.settings.get("gui.xp_bar_config", False) is True:
                     experience_for_next_lvl = int(find_experience_for_level(self.main_pokemon.growth_rate, self.main_pokemon.level, self.settings.get("remove_levelcap", False)))
-                    xp_bar_percent = int((self.main_pokemon.xp / int(experience_for_next_lvl)) * 100)
+                    xp_bar_percent = int((self.main_pokemon.xp / max(1, experience_for_next_lvl)) * 100)
                     reviewer.web.eval('document.getElementById("xp-bar").style.width = "' + str(xp_bar_percent) + '%";')
                 enemy_lang_name = (get_pokemon_diff_lang_name(int(self.enemy_pokemon.id), int(self.settings.get('misc.language'))).capitalize())
                 if self.enemy_pokemon.shiny is True:
@@ -365,9 +366,10 @@ class Reviewer_Manager:
                         main_lang_name += " ⭐ "
                     main_name_display_text = f"{main_lang_name} LvL: {self.main_pokemon.level}"
                     main_hp_display_text = f"HP: {self.main_pokemon.hp}/{self.main_pokemon.max_hp}"
-                    reviewer.web.eval('document.getElementById("mylife-bar").style.width = "' + str(int((self.main_pokemon.hp / self.main_pokemon.max_hp) * 50)) + '%";')
-                    reviewer.web.eval('document.getElementById("mylife-bar").style.background = "linear-gradient(to right, ' + str(myhp_color) + ', ' + str(myhp_color) + ' ' + '100' + '%, ' + 'rgba(54, 54, 56, 0.7)' + '100' + '%, ' + 'rgba(54, 54, 56, 0.7)' + ')";')
-                    reviewer.web.eval('document.getElementById("mylife-bar").style.boxShadow = "0 0 10px ' + myhp_color + ', 0 0 30px rgba(54, 54, 56, 1)";')
+                    if self.settings.get("gui.hp_bar_config", True) is True:
+                        reviewer.web.eval('document.getElementById("mylife-bar").style.width = "' + str(int((self.main_pokemon.hp / max(1, self.main_pokemon.max_hp)) * 50)) + '%";')
+                        reviewer.web.eval('document.getElementById("mylife-bar").style.background = "linear-gradient(to right, ' + str(myhp_color) + ', ' + str(myhp_color) + ' ' + '100' + '%, ' + 'rgba(54, 54, 56, 0.7)' + '100' + '%, ' + 'rgba(54, 54, 56, 0.7)' + ')";')
+                        reviewer.web.eval('document.getElementById("mylife-bar").style.boxShadow = "0 0 10px ' + myhp_color + ', 0 0 30px rgba(54, 54, 56, 1)";')
                     reviewer.web.eval(f'document.getElementById("MyPokeImage").innerHTML = `{new_html_content_mainpkmn}`;')
                     reviewer.web.eval('document.getElementById("myname-display").innerText = "' + main_name_display_text + '";')
                     reviewer.web.eval('document.getElementById("myhp-display").innerText = "' + main_hp_display_text + '";')


### PR DESCRIPTION
## Summary\n- avoid updating reviewer HP DOM nodes when HP bars are disabled\n- use the namespaced XP bar setting and guard zero XP denominators\n- harden multiplayer client errors for non-object JSON responses\n- guard legacy battle HP rendering against zero max HP\n\n## Validation\n- py -3 -m pytest -q (28 passed)\n- py -3 -m compileall -q src/Ankimon\n- graphify update .\n\nSynced and hash-verified against the local Anki addon installation.