### PR TITLE
Use server trainer party data in the battle engine

### DIFF
--- a/src/Ankimon/__init__.py
+++ b/src/Ankimon/__init__.py
@@ -1625,19 +1625,21 @@ def activate_trainer_battle():
     pokemon_id = int(opponent.get("id") or 19)
     level = max(1, int(opponent.get("level") or 5))
     try:
-        stats = search_pokedex(lookup_name, "baseStats")
+        stats = opponent.get("stats") or search_pokedex(lookup_name, "baseStats")
         if not isinstance(stats, dict) or "hp" not in stats:
             raise ValueError(f"no base stats found for {lookup_name}")
-        types = search_pokedex(lookup_name, "types")
-        abilities = search_pokedex(lookup_name, "abilities")
-        numeric_abilities = [value for key, value in (abilities or {}).items() if str(key).isdigit()]
-        ability = random.choice(numeric_abilities) if numeric_abilities else "No Ability"
-        attacks = get_all_pokemon_moves(lookup_name, level)
+        types = opponent.get("type") or search_pokedex(lookup_name, "types")
+        ability = opponent.get("ability") or "No Ability"
+        if not opponent.get("ability"):
+            abilities = search_pokedex(lookup_name, "abilities")
+            numeric_abilities = [value for key, value in (abilities or {}).items() if str(key).isdigit()]
+            ability = random.choice(numeric_abilities) if numeric_abilities else "No Ability"
+        attacks = opponent.get("attacks") or get_all_pokemon_moves(lookup_name, level)
         if not attacks:
             attacks = ["Tackle"]
         attacks = attacks if len(attacks) <= 4 else random.sample(attacks, 4)
-        iv = {key: 15 for key in ("hp", "atk", "def", "spa", "spd", "spe")}
-        ev = {key: 0 for key in ("hp", "atk", "def", "spa", "spd", "spe")}
+        iv = opponent.get("iv") or {key: 15 for key in ("hp", "atk", "def", "spa", "spd", "spe")}
+        ev = opponent.get("ev") or {key: 0 for key in ("hp", "atk", "def", "spa", "spd", "spe")}
         enemy_pokemon.update_stats(
             name=name,
             id=pokemon_id,
@@ -1646,11 +1648,11 @@ def activate_trainer_battle():
             type=types,
             stats=stats,
             attacks=attacks,
-            base_experience=search_pokeapi_db_by_id(pokemon_id, "base_experience"),
-            growth_rate=search_pokeapi_db_by_id(pokemon_id, "growth_rate"),
+            base_experience=opponent.get("base_experience") or search_pokeapi_db_by_id(pokemon_id, "base_experience"),
+            growth_rate=opponent.get("growth_rate") or search_pokeapi_db_by_id(pokemon_id, "growth_rate"),
             ev=ev,
             iv=iv,
-            gender=pick_random_gender(lookup_name),
+            gender=opponent.get("gender") or pick_random_gender(lookup_name),
             battle_status="fighting",
             tier="Normal",
             shiny=False,

--- a/src/Ankimon/functions/create_css_for_reviewer.py
+++ b/src/Ankimon/functions/create_css_for_reviewer.py
@@ -35,6 +35,23 @@ def create_css_for_reviewer(show_mainpkmn_in_reviewer, pokemon_hp_percent, hp_ba
         object-fit: contain;
         image-rendering: pixelated;
     }
+    #PlayerTeam {
+        position: fixed;
+        left: 10px;
+        bottom: 10px;
+        z-index: 10000;
+        display: flex;
+        gap: 2px;
+        padding: 3px;
+        background: rgba(54, 54, 56, 0.7);
+        border-radius: 6px;
+    }
+    #PlayerTeam img {
+        width: 22px;
+        height: 22px;
+        object-fit: contain;
+        image-rendering: pixelated;
+    }
     #RaidBossImage {
         position: fixed;
         right: 10px;

--- a/src/Ankimon/pyobj/reviewer_obj.py
+++ b/src/Ankimon/pyobj/reviewer_obj.py
@@ -1,4 +1,5 @@
 import copy
+import json
 
 from aqt import gui_hooks, mw, utils
 from aqt.utils import showInfo
@@ -7,7 +8,7 @@ from ..business import get_image_as_base64
 from ..functions.create_css_for_reviewer import create_css_for_reviewer
 from ..texts import inject_life_bar_css_1, inject_life_bar_css_2
 from ..functions.create_gui_functions import create_status_html
-from ..resources import icon_path, trainer_sprites_path
+from ..resources import icon_path, mypokemon_path, trainer_sprites_path
 from ..functions.pokedex_functions import get_pokemon_diff_lang_name
 
 class Reviewer_Manager:
@@ -128,6 +129,43 @@ class Reviewer_Manager:
             )
         return f'<div id="OpponentTeam" class="Ankimon">{"".join(balls)}</div>'
 
+    def _player_team_html(self):
+        """Show the selected player's party in the lower-left reviewer corner."""
+        selected = self.settings.get("trainer.team", []) or []
+        if not isinstance(selected, list) or not selected:
+            return ""
+        selected_ids = {
+            str(entry.get("individual_id")) for entry in selected
+            if isinstance(entry, dict) and entry.get("individual_id")
+        }
+        if not selected_ids:
+            return ""
+        try:
+            with open(mypokemon_path, "r", encoding="utf-8") as file:
+                owned = json.load(file)
+        except (OSError, TypeError, ValueError):
+            owned = []
+        team = [pokemon for pokemon in owned
+                if str(pokemon.get("individual_id")) in selected_ids]
+        if not team:
+            return ""
+        active_id = str(getattr(self.main_pokemon, "individual_id", ""))
+        ball = get_image_as_base64(icon_path)
+        balls = []
+        for pokemon in team:
+            pokemon_id = str(pokemon.get("individual_id", ""))
+            status = "active" if pokemon_id == active_id else "available"
+            if int(pokemon.get("current_hp", 1) or 0) <= 0:
+                status = "fainted"
+            opacity = "1" if status != "fainted" else "0.35"
+            outline = "border:1px solid rgba(255,215,80,.9);" if status == "active" else ""
+            name = str(pokemon.get("name", "Pokémon")).replace("`", "")
+            balls.append(
+                f'<img src="data:image/png;base64,{ball}" alt="{name} {status}" '
+                f'title="{name}" style="opacity:{opacity};{outline}">'
+            )
+        return f'<div id="PlayerTeam" class="Ankimon">{"".join(balls)}</div>'
+
     def reviewer_reset_life_bar_inject(self):
         self.life_bar_injected = False
 
@@ -245,6 +283,7 @@ class Reviewer_Manager:
                     web_content.body += f'<div id="PokeImage" class="Ankimon"><img src="data:image/png;base64,{image_base64}" alt="PokeImage style="animation: shake 0s ease;"></div>'
                     web_content.body += self._trainer_image_html()
                     web_content.body += self._trainer_team_html()
+                    web_content.body += self._player_team_html()
                     web_content.body += self._raid_boss_html()
                     if int(self.settings.get('gui.show_mainpkmn_in_reviewer', 1)) > 0:
                         image_base64_mypkmn = get_image_as_base64(main_pkmn_imagefile_path)
@@ -357,6 +396,11 @@ class Reviewer_Manager:
                 reviewer.web.eval(
                     f'{{const team = document.getElementById("OpponentTeam"); '
                     f'if (team) team.outerHTML = `{team_html}`;}}'
+                )
+                player_team_html = self._player_team_html()
+                reviewer.web.eval(
+                    f'{{const team = document.getElementById("PlayerTeam"); '
+                    f'if (team) team.outerHTML = `{player_team_html}`;}}'
                 )
                 reviewer.web.eval(f'document.getElementById("pokestatus").innerHTML = `{status_html}`;')
                 if int(self.settings.get('gui.show_mainpkmn_in_reviewer', 1)) > 0:

--- a/src/Ankimon/pyobj/trainer_bot_dialog.py
+++ b/src/Ankimon/pyobj/trainer_bot_dialog.py
@@ -114,6 +114,7 @@ class TrainerBotDialog(QDialog):
             f"<b>{bot.get('trainer_name', bot.get('username', 'Trainer'))}</b>"
             f" &mdash; {bot.get('trainer_rank', 'Trainer')}<br>"
             f"{bot.get('motto', '')}<br>"
+            f"Difficulty: <b>{bot.get('difficulty_name', bot.get('difficulty', '?'))}</b><br>"
             f"Pokémon: {bot.get('pokemon', '?')} · Lv. {bot.get('level', '?')}"
             f"{battle_text}"
         )


### PR DESCRIPTION
## Summary\n- consume server-provided base stats, IVs, EVs, abilities, types, moves, growth rate, and gender\n- keep trainer battle Pokemon aligned with the server-calculated max HP\n- show each trainer's difficulty in the battle roster\n\n## Validation\n- py -3 -m pytest -q (28 passed)\n- py -3 -m compileall -q src/Ankimon\n- synced and hash-verified against the local Anki addon installation