### PR TITLE
Make trainer battles easier to launch

### DIFF
--- a/src/Ankimon/menu_buttons.py
+++ b/src/Ankimon/menu_buttons.py
@@ -222,9 +222,21 @@ def create_menu_actions(
     raid_button.triggered.connect(lambda: RaidDialog(mw.raid_session_obj).exec())
     multiplayer_menu.addAction(raid_button)
 
+    def open_trainer_battles():
+        """Open trainer battles with a visible error instead of a silent menu failure."""
+        try:
+            TrainerBotDialog(mw).exec()
+        except Exception as exc:
+            QMessageBox.critical(
+                mw,
+                "Trainer Battles",
+                f"Could not open Trainer Battles:\n{exc}",
+            )
+
     trainer_battle_button = QAction("Trainer Battles", mw)
     trainer_battle_button.setMenuRole(QAction.MenuRole.NoRole)
-    trainer_battle_button.triggered.connect(lambda: TrainerBotDialog(mw).exec())
+    trainer_battle_button.setShortcut(QKeySequence("Ctrl+Shift+B"))
+    trainer_battle_button.triggered.connect(open_trainer_battles)
     multiplayer_menu.addAction(trainer_battle_button)
 
     # Button: Show credits


### PR DESCRIPTION
## Summary\n- replace the inline Trainer Battles lambda with a guarded launcher\n- show a clear Qt error if dialog initialization fails\n- add Ctrl+Shift+B shortcut while keeping Multiplayer > Trainer Battles\n\n## Validation\n- py -3 -m pytest -q (28 passed)\n- py -3 -m compileall -q src/Ankimon\n- synced and hash-verified to the local Anki addon