### PR TITLE
Preserve zero HP for trainer battle opponents

### DIFF
--- a/src/Ankimon/__init__.py
+++ b/src/Ankimon/__init__.py
@@ -1665,7 +1665,8 @@ def activate_trainer_battle():
 
     calculated_hp = max(1, int(enemy_pokemon.calculate_max_hp()))
     server_max_hp = max(1, int(opponent.get("max_hp") or calculated_hp))
-    server_hp = max(0, int(opponent.get("hp") or server_max_hp))
+    server_hp_value = opponent.get("hp")
+    server_hp = server_max_hp if server_hp_value is None else max(0, int(server_hp_value))
     enemy_pokemon.max_hp = calculated_hp
     enemy_pokemon.hp = min(calculated_hp, round(server_hp / server_max_hp * calculated_hp))
     enemy_pokemon.current_hp = enemy_pokemon.hp


### PR DESCRIPTION
## Summary\n- preserve a server-reported 0 HP during trainer battle initialization\n- prevent fainted bot Pokémon from being revived by an or fallback\n\n## Validation\n- py -3 -m pytest -q (28 passed)\n- py -3 -m compileall -q src/Ankimon\n- graphify update .\n- synced and hash-verified to the local Anki addon